### PR TITLE
Changed with_deleted from self.unscoped.where() to self.unscoped.reload - tests pass now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+rails3_acts_as_paranoid-*.gem

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -19,7 +19,7 @@ module ActsAsParanoid
 
       class << self
         def with_deleted
-          self.unscoped.where() # ugly, but it re-fetches the data (no caching)
+          self.unscoped.reload
         end
 
         def only_deleted

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib/', __FILE__)
+$:.unshift lib unless $:.include?(lib)
+
+Gem::Specification.new do |s|
+  s.name        = "rails3_acts_as_paranoid"
+  s.version     = "0.0.1"
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = "Gonçalo Silva"
+  s.email       = "goncalossilva@gmail.com"
+  s.homepage    = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
+  s.summary     = "ActiveRecord (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
+  s.description = "ActiveRecord (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
+  s.files        = Dir.glob("lib/**/*") + %w(MIT-LICENSE README.markdown Rakefile)
+  s.require_path = 'lib'
+end


### PR DESCRIPTION
Before my change I got these errors:

```
Started
-- create_table(:paranoid_times)
 -> 0.0016s
-- create_table(:paranoid_booleans)
 -> 0.0009s
-- create_table(:not_paranoids)
 -> 0.0007s
-- initialize_schema_migrations_table()
 -> 0.0009s
-- assume_migrated_upto_version(1, "db/migrate")
 -> 0.0003s
E-- create_table(:paranoid_times)
 -> 0.0009s
-- create_table(:paranoid_booleans)
 -> 0.0007s
-- create_table(:not_paranoids)
 -> 0.0007s
-- initialize_schema_migrations_table()
 -> 0.0008s
-- assume_migrated_upto_version(1, "db/migrate")
 -> 0.0003s
.-- create_table(:paranoid_times)
 -> 0.0008s
-- create_table(:paranoid_booleans)
 -> 0.0008s
-- create_table(:not_paranoids)
 -> 0.0007s
-- initialize_schema_migrations_table()
 -> 0.0008s
-- assume_migrated_upto_version(1, "db/migrate")
 -> 0.0003s
E-- create_table(:paranoid_times)
 -> 0.0009s
-- create_table(:paranoid_booleans)
 -> 0.0009s
-- create_table(:not_paranoids)
 -> 0.0007s
-- initialize_schema_migrations_table()
 -> 0.0008s
-- assume_migrated_upto_version(1, "db/migrate")
 -> 0.0002s
.
Finished in 0.146757 seconds.

1) Error:
test_fake_removal(ParanoidTest):
ArgumentError: wrong number of arguments (0 for 1)
  /Users/user/.rvm/gems/ruby-1.9.2-head/gems/activerecord-3.0.0/lib/active_record/relation/query_methods.rb:50:in `where'
  (eval):5:in `with_deleted'
  test/rails3_acts_as_paranoid_test.rb:55:in `test_fake_removal'

2) Error:
test_real_removal(ParanoidTest):
ArgumentError: wrong number of arguments (0 for 1)
  /Users/user/.rvm/gems/ruby-1.9.2-head/gems/activerecord-3.0.0/lib/active_record/relation/query_methods.rb:50:in `where'
  (eval):5:in `with_deleted'
  test/rails3_acts_as_paranoid_test.rb:64:in `test_real_removal'

4 tests, 11 assertions, 0 failures, 2 errors, 0 skips

Test run options: --seed 41205
rake aborted!
Command failed with status (1): [/Users/user/.rvm/rubies/ruby-...]

# ruby -v
ruby 1.9.2p0 (2010-08-18 revision 29034) [x86_64-darwin10.4.0]
```
