### PR TITLE
Recursive recover

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -98,18 +98,18 @@ module ActsAsParanoid
 
       def recover_dependent_associations(window, options)
         self.class.dependent_associations.each do |association|
-          if association.collection?
+          if association.collection? && self.send(association.name).is_paranoid?
             self.send(association.name).unscoped do
               self.send(association.name).deleted_around(paranoid_value, window).each do |object|
                 object.recover(options) if object.respond_to?(:recover)
               end
             end
-          elsif association.macro == :has_one
+          elsif association.macro == :has_one && association.klass.is_paranoid?
             association.klass.unscoped do
               object = association.klass.deleted_around(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
               object.recover(options) if object && object.respond_to?(:recover)
             end
-          else
+          elsif association.klass.is_paranoid?
             association.klass.unscoped do
               id = self.send(association.primary_key_name)
               object = association.klass.deleted_around(paranoid_value, window).find_by_id(id)

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -1,10 +1,18 @@
 require 'active_record'
 
+class Object
+  class << self
+    def is_paranoid?
+      false
+    end
+  end
+end
+
 module ActsAsParanoid
   def acts_as_paranoid(options = {})
     raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
 
-    configuration = { :column => "deleted_at", :column_type => "time" }
+    configuration = { :column => "deleted_at", :column_type => "time", :dependent_recover => true, :dependent_recovery_window => 5.seconds }
     configuration.update(options) unless options.nil?
 
     type = case configuration[:column_type]
@@ -14,30 +22,22 @@ module ActsAsParanoid
         raise ArgumentError, "'time' or 'boolean' expected for :column_type option, got #{configuration[:column_type]}"
     end
 
-    only_deleted_method_code = 
-    if configuration[:column_type] == 'time'
-      <<-EOV
-      self.unscoped.
-        where("#{self.table_name}.#{configuration[:column]} IS NOT ?", nil)
-EOV
-    else
-      <<-EOV
-      self.unscoped.
-        where("#{self.table_name}.#{configuration[:column]} IS NOT ?
-          OR #{self.table_name}.#{configuration[:column]} != ?", nil, true)
-EOV
-    end
+    column_reference = "#{self.table_name}.#{configuration[:column]}"
 
     class_eval <<-EOV
-      default_scope where("#{self.table_name}.#{configuration[:column]} IS ?", nil)
+      default_scope where("#{column_reference} IS ?", nil)
 
       class << self
+        def is_paranoid?
+          true
+        end
+
         def with_deleted
           self.unscoped.reload
         end
 
         def only_deleted
-          #{only_deleted_method_code}
+          self.unscoped.where("#{column_reference} IS NOT ?", nil)
         end
 
         def delete_all!(conditions = nil)
@@ -47,6 +47,22 @@ EOV
         def delete_all(conditions = nil)
           update_all ["#{configuration[:column]} = ?", #{type}], conditions
         end
+
+        def paranoid_column
+          :"#{configuration[:column]}"
+        end
+
+        def paranoid_column_type
+          :"#{configuration[:column_type]}"
+        end
+
+        def dependent_associations
+          self.reflect_on_all_associations.select {|a| a.options[:dependent] == :destroy }
+        end
+      end
+
+      def paranoid_value
+        self.send(self.class.paranoid_column)
       end
 
       def destroy!
@@ -59,7 +75,7 @@ EOV
 
       def destroy
         run_callbacks :destroy do
-          if self.#{configuration[:column]} == nil
+          if paranoid_value == nil
             #{self.name}.delete_all(:id => self.id)
           else
             #{self.name}.delete_all!(:id => self.id)
@@ -67,10 +83,52 @@ EOV
         end
       end
 
-      def recover
-        self.update_attribute(:#{configuration[:column]}, nil)
+      def recover(options = {})
+        options = {
+                    :recover_associations => #{configuration[:dependent_recover]},
+                    :dependent_recovery_window => #{configuration[:dependent_recovery_window]}
+                  }.merge(options)
+
+        self.class.transaction do
+          recover_dependent_associations(options[:dependent_recovery_window], options) if options[:recover_associations]
+
+          self.update_attribute(self.class.paranoid_column, nil)
+        end
       end
-      
+
+      def recover_dependent_associations(window, options)
+        self.class.dependent_associations.each do |association|
+          if association.collection?
+            self.send(association.name).unscoped do
+              self.send(association.name).deleted_around(paranoid_value, window).each do |object|
+                object.recover(options) if object.respond_to?(:recover)
+              end
+            end
+          elsif association.macro == :has_one
+            association.klass.unscoped do
+              object = association.klass.deleted_around(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
+              object.recover(options) if object && object.respond_to?(:recover)
+            end
+          else
+            association.klass.unscoped do
+              id = self.send(association.primary_key_name)
+              object = association.klass.deleted_around(paranoid_value, window).find_by_id(id)
+              object.recover(options) if object && object.respond_to?(:recover)
+            end
+          end
+        end
+      end
+
+      scope :deleted_around, lambda {|value, window|
+        if self.class.is_paranoid?
+          if self.class.paranoid_column_type == 'time' && ![true, false].include?(value)
+            self.where("\#{self.class.paranoid_column} > ? AND \#{self.class.paranoid_column} < ?", (value - window), (value + window))
+          else
+            self.only_deleted
+          end
+        end
+      }
+
       ActiveRecord::Relation.class_eval do
         alias_method :delete_all!, :delete_all
         alias_method :destroy!, :destroy

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -12,7 +12,7 @@ module ActsAsParanoid
   def acts_as_paranoid(options = {})
     raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
 
-    configuration = { :column => "deleted_at", :column_type => "time", :dependent_recover => true, :dependent_recovery_window => 5.seconds }
+    configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 5.seconds }
     configuration.update(options) unless options.nil?
 
     type = case configuration[:column_type]
@@ -85,12 +85,12 @@ module ActsAsParanoid
 
       def recover(options = {})
         options = {
-                    :recover_associations => #{configuration[:dependent_recover]},
-                    :dependent_recovery_window => #{configuration[:dependent_recovery_window]}
+                    :recursive => #{configuration[:recover_dependent_associations]},
+                    :recovery_window => #{configuration[:dependent_recovery_window]}
                   }.merge(options)
 
         self.class.transaction do
-          recover_dependent_associations(options[:dependent_recovery_window], options) if options[:recover_associations]
+          recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
           self.update_attribute(self.class.paranoid_column, nil)
         end

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -95,12 +95,21 @@ class ParanoidTest < ActiveSupport::TestCase
       paranoid_boolean = @paranoid_time_object.paranoid_booleans.create(:name => "boolean_#{i}")
       paranoid_boolean.create_paranoid_has_one_dependant(:name => "has_one_#{i}")
       paranoid_boolean.save
+
+      @paranoid_time_object.not_paranoids.create(:name => "not_paranoid_a#{i}")
+
     end
+
+    @paranoid_time_object.create_not_paranoid(:name => "not_paranoid_belongs_to")
+
+    @paranoid_time_object.create_has_one_not_paranoid(:name => "has_one_not_paranoid")
 
     assert_equal 3, ParanoidTime.count
     assert_equal 3, ParanoidHasManyDependant.count
     assert_equal 3, ParanoidBelongsDependant.count
     assert_equal 3, ParanoidHasOneDependant.count
+    assert_equal 5, NotParanoid.count
+    assert_equal 1, HasOneNotParanoid.count
     assert_equal @paranoid_boolean_count + 3, ParanoidBoolean.count
 
     @paranoid_time_object.destroy
@@ -110,6 +119,9 @@ class ParanoidTest < ActiveSupport::TestCase
     assert_equal 0, ParanoidHasManyDependant.count
     assert_equal 0, ParanoidBelongsDependant.count
     assert_equal 0, ParanoidHasOneDependant.count
+    puts NotParanoid.all.inspect
+    assert_equal 1, NotParanoid.count
+    assert_equal 0, HasOneNotParanoid.count
     assert_equal @paranoid_boolean_count, ParanoidBoolean.count
   end
 
@@ -122,6 +134,8 @@ class ParanoidTest < ActiveSupport::TestCase
     assert_equal 3, ParanoidHasManyDependant.count
     assert_equal 3, ParanoidBelongsDependant.count
     assert_equal 3, ParanoidHasOneDependant.count
+    assert_equal 1, NotParanoid.count
+    assert_equal 0, HasOneNotParanoid.count
     assert_equal @paranoid_boolean_count + 3, ParanoidBoolean.count
   end
 
@@ -134,6 +148,8 @@ class ParanoidTest < ActiveSupport::TestCase
     assert_equal 0, ParanoidHasManyDependant.count
     assert_equal 0, ParanoidBelongsDependant.count
     assert_equal 0, ParanoidHasOneDependant.count
+    assert_equal 1, NotParanoid.count
+    assert_equal 0, HasOneNotParanoid.count
     assert_equal @paranoid_boolean_count, ParanoidBoolean.count
 
   end

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -116,7 +116,7 @@ class ParanoidTest < ActiveSupport::TestCase
   def test_recursive_recovery
     setup_recursive_recovery_tests
 
-    @paranoid_time_object.recover(:recover_associations => true)
+    @paranoid_time_object.recover(:recursive => true)
 
     assert_equal 3, ParanoidTime.count
     assert_equal 3, ParanoidHasManyDependant.count
@@ -128,7 +128,7 @@ class ParanoidTest < ActiveSupport::TestCase
   def test_non_recursive_recovery
     setup_recursive_recovery_tests
 
-    @paranoid_time_object.recover(:recover_associations => false)
+    @paranoid_time_object.recover(:recursive => false)
 
     assert_equal 3, ParanoidTime.count
     assert_equal 0, ParanoidHasManyDependant.count

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,23 +11,49 @@ ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":me
 def setup_db
   ActiveRecord::Schema.define(:version => 1) do
     create_table :paranoid_times do |t|
-      t.column :name, :string
-      t.column :deleted_at, :datetime
-      t.column :created_at, :datetime      
-      t.column :updated_at, :datetime
+      t.string    :name
+      t.datetime  :deleted_at
+      t.integer   :paranoid_belongs_dependant_id
+
+      t.timestamps
     end
 
     create_table :paranoid_booleans do |t|
-      t.column :name, :string
-      t.column :is_deleted, :boolean
-      t.column :created_at, :datetime      
-      t.column :updated_at, :datetime
+      t.string    :name
+      t.boolean   :is_deleted
+      t.integer   :paranoid_time_id
+
+      t.timestamps
     end
 
     create_table :not_paranoids do |t|
-      t.column :name, :string
-      t.column :created_at, :datetime      
-      t.column :updated_at, :datetime
+      t.string    :name
+
+      t.timestamps
+    end
+
+    create_table :paranoid_has_many_dependants do |t|
+      t.string    :name
+      t.datetime  :deleted_at
+      t.integer   :paranoid_time_id
+      t.integer   :paranoid_belongs_dependant_id
+
+      t.timestamps
+    end
+
+    create_table :paranoid_belongs_dependants do |t|
+      t.string    :name
+      t.datetime  :deleted_at
+
+      t.timestamps
+    end
+
+    create_table :paranoid_has_one_dependants do |t|
+      t.string    :name
+      t.datetime  :deleted_at
+      t.integer   :paranoid_boolean_id
+
+      t.timestamps
     end
   end
 end
@@ -40,11 +66,36 @@ end
 
 class ParanoidTime < ActiveRecord::Base
   acts_as_paranoid
+
+  has_many :paranoid_has_many_dependants, :dependent => :destroy
+  has_many :paranoid_booleans, :dependent => :destroy
 end
 
 class ParanoidBoolean < ActiveRecord::Base
   acts_as_paranoid :column_type => "boolean", :column => "is_deleted"
+
+  belongs_to :paranoid_time
+  has_one :paranoid_has_one_dependant, :dependent => :destroy
 end
 
 class NotParanoid < ActiveRecord::Base
+end
+
+class ParanoidHasManyDependant < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_time
+
+  belongs_to :paranoid_belongs_dependant, :dependent => :destroy
+end
+
+class ParanoidBelongsDependant < ActiveRecord::Base
+  acts_as_paranoid
+
+  has_many :paranoid_has_many_dependants
+end
+
+class ParanoidHasOneDependant < ActiveRecord::Base
+  acts_as_paranoid
+
+  belongs_to :paranoid_boolean
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,8 @@ def setup_db
       t.datetime  :deleted_at
       t.integer   :paranoid_belongs_dependant_id
 
+      t.integer   :not_paranoid_id
+
       t.timestamps
     end
 
@@ -28,6 +30,16 @@ def setup_db
 
     create_table :not_paranoids do |t|
       t.string    :name
+
+      t.integer   :paranoid_time_id
+
+      t.timestamps
+    end
+
+    create_table :has_one_not_paranoids do |t|
+      t.string    :name
+
+      t.integer   :paranoid_time_id
 
       t.timestamps
     end
@@ -69,6 +81,11 @@ class ParanoidTime < ActiveRecord::Base
 
   has_many :paranoid_has_many_dependants, :dependent => :destroy
   has_many :paranoid_booleans, :dependent => :destroy
+  has_many :not_paranoids, :dependent => :destroy
+
+  has_one :has_one_not_paranoid, :dependent => :destroy
+
+  belongs_to :not_paranoid, :dependent => :destroy
 end
 
 class ParanoidBoolean < ActiveRecord::Base
@@ -79,6 +96,9 @@ class ParanoidBoolean < ActiveRecord::Base
 end
 
 class NotParanoid < ActiveRecord::Base
+end
+
+class HasOneNotParanoid < ActiveRecord::Base
 end
 
 class ParanoidHasManyDependant < ActiveRecord::Base


### PR DESCRIPTION
I thought I had done a pull request for this earlier, but apparently it didn't go through!

I extended the recover method here to allow for recursive recovery of object associations so that, taking a Blog as an example, recovering an Article object would automatically recover the associated Comment objects if they were marked as :dependent => :destroy.

For time-based paranoid fields, it can also recursively recover those associated objects within a certain time frame so that you only get the ones that were deleted at the same time as the main object.

I've also included tests.
