### PR TITLE
Ensure validation of records before recovering them

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -93,7 +93,7 @@ module ActsAsParanoid
         self.class.transaction do
           recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
-          self.update_attribute(self.class.paranoid_column, nil)
+          self.update_attributes(self.class.paranoid_column.to_sym => nil)
         end
       end
 


### PR DESCRIPTION
[update_attribute](http://apidock.com/rails/ActiveRecord/Base/update_attribute) skips validation. As we need records to be validated before recovering them, I suggest to use [update_attributes](http://apidock.com/rails/ActiveRecord/Base/update_attributes) instead. 
