### PR TITLE
Small change to restore functionality

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -57,7 +57,7 @@ module ActsAsParanoid
         end
 
         def dependent_associations
-          self.reflect_on_all_associations.select {|a| a.options[:dependent] == :destroy }
+          self.reflect_on_all_associations.select {|a| [:delete_all, :destroy].include?(a.options[:dependent]) }
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,7 +81,7 @@ class ParanoidTime < ActiveRecord::Base
 
   has_many :paranoid_has_many_dependants, :dependent => :destroy
   has_many :paranoid_booleans, :dependent => :destroy
-  has_many :not_paranoids, :dependent => :destroy
+  has_many :not_paranoids, :dependent => :delete_all
 
   has_one :has_one_not_paranoid, :dependent => :destroy
 


### PR DESCRIPTION
Before the restore functionality wouldn't work for dependencies that were :delete_all (just :destroy).  I've fixed that here and adjusted the tests to include a sample
