### PR TITLE
Cleanup and support for after_commit destroy callbacks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ GEM
     arel (1.0.1)
       activesupport (~> 3.0.0)
     builder (2.1.2)
-    i18n (0.4.1)
+    i18n (0.4.2)
     rake (0.8.7)
     sqlite3-ruby (1.3.2)
-    tzinfo (0.3.23)
+    tzinfo (0.3.25)
 
 PLATFORMS
   ruby

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -1,151 +1,168 @@
 require 'active_record'
 require 'validations/uniqueness_without_deleted'
 
-class Object
-  class << self
-    def is_paranoid?
-      false
-    end
-  end
-end
-
 module ActsAsParanoid
-  def acts_as_paranoid(options = {})
-    raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
-
-    configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 5.minutes }
-    configuration.update(options) unless options.nil?
-
-    type = case configuration[:column_type]
-      when "time" then "Time.now"
-      when "boolean" then "true"
-      else
-        raise ArgumentError, "'time' or 'boolean' expected for :column_type option, got #{configuration[:column_type]}"
-    end
-
-    column_reference = "#{self.table_name}.#{configuration[:column]}"
-
-    class_eval <<-EOV
-      default_scope where("#{column_reference} IS ?", nil)
-
-      class << self
-        def is_paranoid?
-          true
-        end
-
-        def with_deleted
-          self.unscoped.where("") #self.unscoped.reload
-        end
-
-        def only_deleted
-          self.unscoped.where("#{column_reference} IS NOT ?", nil)
-        end
-
-        def delete_all!(conditions = nil)
-          self.unscoped.delete_all!(conditions)
-        end
-
-        def delete_all(conditions = nil)
-          update_all ["#{configuration[:column]} = ?", #{type}], conditions
-        end
-
-        def paranoid_column
-          :"#{configuration[:column]}"
-        end
-
-        def paranoid_column_type
-          :"#{configuration[:column_type]}"
-        end
-
-        def dependent_associations
-          self.reflect_on_all_associations.select {|a| [:delete_all, :destroy].include?(a.options[:dependent]) }
-        end
-      end
-
-      def paranoid_value
-        self.send(self.class.paranoid_column)
-      end
-
-      def destroy!
-        before_destroy() if respond_to?(:before_destroy)
-
-        #{self.name}.delete_all!(:id => self)
-
-        after_destroy() if respond_to?(:after_destroy)
-      end
-
-      def destroy
-        run_callbacks :destroy do
-          if paranoid_value == nil
-            #{self.name}.delete_all(:id => self.id)
-          else
-            #{self.name}.delete_all!(:id => self.id)
-          end
-        end
-      end
-
-      def recover(options = {})
-        options = {
-                    :recursive => #{configuration[:recover_dependent_associations]},
-                    :recovery_window => #{configuration[:dependent_recovery_window]}
-                  }.merge(options)
-
-        self.class.transaction do
-          recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
-
-          self.update_attributes(self.class.paranoid_column.to_sym => nil)
-        end
-      end
-
-      def recover_dependent_associations(window, options)
-        self.class.dependent_associations.each do |association|
-          if association.collection? && self.send(association.name).is_paranoid?
-            self.send(association.name).unscoped do
-              self.send(association.name).deleted_around(paranoid_value, window).each do |object|
-                object.recover(options) if object.respond_to?(:recover)
-              end
-            end
-          elsif association.macro == :has_one && association.klass.is_paranoid?
-            association.klass.unscoped do
-              object = association.klass.deleted_around(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
-              object.recover(options) if object && object.respond_to?(:recover)
-            end
-          elsif association.klass.is_paranoid?
-            association.klass.unscoped do
-              id = self.send(association.primary_key_name)
-              object = association.klass.deleted_around(paranoid_value, window).find_by_id(id)
-              object.recover(options) if object && object.respond_to?(:recover)
-            end
-          end
-        end
-      end
-
-      def deleted?
-        !self.#{configuration[:column]}.nil?
-      end
-
-      scope :deleted_around, lambda {|value, window|
-        if self.class.is_paranoid?
-          if self.class.paranoid_column_type == 'time' && ![true, false].include?(value)
-            self.where("\#{self.class.paranoid_column} > ? AND \#{self.class.paranoid_column} < ?", (value - window), (value + window))
-          else
-            self.only_deleted
-          end
-        end
-      }
-
-      ActiveRecord::Relation.class_eval do
-        alias_method :delete_all!, :delete_all
-        alias_method :destroy!, :destroy
-      end
-    EOV
+  
+  def paranoid?
+    self.included_modules.include?(InstanceMethods)
   end
   
   def validates_as_paranoid
-    class_eval <<-EOV
-      send :extend, ParanoidValidations::ClassMethods
-    EOV
+    extend ParanoidValidations::ClassMethods
   end
+  
+  def acts_as_paranoid(options = {})
+    raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
+    
+    return if paranoid?
+    
+    class << self
+      attr_accessor :paranoid_configuration, :paranoid_column_reference
+    end
+     
+    @paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 5.minutes }.merge(options)
+
+    raise ArgumentError, "'time' or 'boolean' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean'].include? paranoid_configuration[:column_type]
+
+    @paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
+
+    ActiveRecord::Relation.class_eval do
+      alias_method :delete_all!, :delete_all
+      alias_method :destroy!, :destroy
+    end
+    
+    default_scope where("#{paranoid_column_reference} IS ?", nil)
+    
+    scope :deleted_around, lambda {|value, window|
+      if self.class.respond_to?(:paranoid?) && self.class.paranoid?
+        if self.class.paranoid_column_type == 'time' && ![true, false].include?(value)
+          self.where("#{self.class.paranoid_column} > ? AND #{self.class.paranoid_column} < ?", (value - window), (value + window))
+        else
+          self.only_deleted
+        end
+      end
+    }
+    
+    include InstanceMethods
+    extend ClassMethods
+  end
+
+  module ClassMethods
+    
+    def with_deleted
+      self.unscoped.reload
+    end
+
+    def only_deleted
+      self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+    end
+
+    def delete_all!(conditions = nil)
+      self.unscoped.delete_all!(conditions)
+    end
+
+    def delete_all(conditions = nil)
+      update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
+    end
+
+    def paranoid_column
+      paranoid_configuration[:column].to_sym
+    end
+
+    def paranoid_column_type
+      paranoid_configuration[:column_type].to_sym
+    end
+
+    def dependent_associations
+      self.reflect_on_all_associations.select {|a| [:delete_all, :destroy].include?(a.options[:dependent]) }
+    end
+  
+    def delete_now_value
+      case paranoid_configuration[:column_type]
+        when "time" then Time.now
+        when "boolean" then true
+      end
+    end
+  
+  end
+  
+  module InstanceMethods
+    
+    def paranoid_value
+      self.send(self.class.paranoid_column)
+    end
+  
+    def destroy!
+      with_transaction_returning_status do
+        run_callbacks :destroy do
+          self.class.delete_all!(:id => self)
+          self.paranoid_value = self.class.delete_now_value
+          freeze
+        end
+      end
+    end
+
+    def destroy
+      with_transaction_returning_status do
+        run_callbacks :destroy do
+          if paranoid_value == nil
+            self.class.delete_all(:id => self.id)
+          else
+            self.class.delete_all!(:id => self.id)
+          end
+          self.paranoid_value = self.class.delete_now_value
+        end
+      end
+    end
+
+    def recover(options = {})
+      options = {
+                  :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
+                  :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
+                }.merge(options)
+
+      self.class.transaction do
+        recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
+
+        self.update_attributes(self.class.paranoid_column.to_sym => nil)
+      end
+    end
+
+    def recover_dependent_associations(window, options)
+      self.class.dependent_associations.each do |association|
+        if association.collection? && self.send(association.name).paranoid?
+          self.send(association.name).unscoped do
+            self.send(association.name).deleted_around(paranoid_value, window).each do |object|
+              object.recover(options) if object.respond_to?(:recover)
+            end
+          end
+        elsif association.macro == :has_one && association.klass.paranoid?
+          association.klass.unscoped do
+            object = association.klass.deleted_around(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
+            object.recover(options) if object && object.respond_to?(:recover)
+          end
+        elsif association.klass.paranoid?
+          association.klass.unscoped do
+            id = self.send(association.primary_key_name)
+            object = association.klass.deleted_around(paranoid_value, window).find_by_id(id)
+            object.recover(options) if object && object.respond_to?(:recover)
+          end
+        end
+      end
+    end
+
+    def deleted?
+      !paranoid_value.nil?
+    end
+    alias_method :destroyed?, :deleted?
+    
+  private
+    def paranoid_value=(value)
+      self.send("#{self.class.paranoid_column}=", value)
+    end
+    
+  end
+  
 end
 
 # Extend ActiveRecord's functionality

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,12 +1,12 @@
 # coding: UTF-8
 
 Gem::Specification.new do |s|
-  s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.0.4"
+  s.name              = "phene-rails3_acts_as_paranoid"
+  s.version           = "0.0.5"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Gonçalo Silva"]
-  s.email             = ["goncalossilva@gmail.com"]
-  s.homepage          = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
+  s.authors           = ["Geoffrey Hichborn"]
+  s.email             = ["geoff@socialcast.com"]
+  s.homepage          = "http://github.com/phene/rails3_acts_as_paranoid"
   s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
   s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,6 +71,13 @@ def setup_db
 
       t.timestamps
     end
+    
+    create_table :paranoid_with_callbacks do |t|
+      t.string    :name
+      t.datetime  :deleted_at
+      
+      t.timestamps
+    end
   end
 end
 
@@ -125,4 +132,33 @@ class ParanoidHasOneDependant < ActiveRecord::Base
   acts_as_paranoid
 
   belongs_to :paranoid_boolean
+end
+
+class ParanoidWithCallback < ActiveRecord::Base
+  acts_as_paranoid
+  
+  attr_accessor :called_before_destroy, :called_after_destroy, :called_after_commit_on_destroy
+  
+  before_destroy :call_me_before_destroy
+  after_destroy :call_me_after_destroy
+  
+  after_commit :call_me_after_commit_on_destroy, :on => :destroy
+  
+  def initialize(*attrs)
+    @called_before_destroy = @called_after_destroy = @called_after_commit_on_destroy = false
+    super(*attrs)
+  end
+  
+  def call_me_before_destroy
+    @called_before_destroy = true
+  end
+  
+  def call_me_after_destroy
+    @called_after_destroy = true
+  end
+  
+  def call_me_after_commit_on_destroy
+    @called_after_commit_on_destroy = true
+  end
+  
 end


### PR DESCRIPTION
Renamed is_paranoid? to paranoid? and removed from Object class
Rewrote acts_as_paranoid to include/extend Instance/Class method modules instead of using class_eval
Added support for the destroy callback chain w/ tests
