### PR TITLE
Added support for Active Record STI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails3_acts_as_paranoid (0.0.5)
+    rails3_acts_as_paranoid (0.0.6)
       activerecord (>= 3.0)
 
 GEM

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -88,14 +88,14 @@ module ActsAsParanoid
   module InstanceMethods
     
     def paranoid_value
-      self.send(self.class.paranoid_column)
+      self.send(self.class.base_class.paranoid_column)
     end
   
     def destroy!
       with_transaction_returning_status do
         run_callbacks :destroy do
-          self.class.delete_all!(:id => self.id)
-          self.paranoid_value = self.class.delete_now_value
+          self.class.base_class.delete_all!(:id => self.id)
+          self.paranoid_value = self.class.base_class.delete_now_value
           freeze
         end
       end
@@ -105,25 +105,25 @@ module ActsAsParanoid
       with_transaction_returning_status do
         run_callbacks :destroy do
           if paranoid_value.nil?
-            self.class.delete_all(:id => self.id)
+            self.class.base_class.delete_all(:id => self.id)
           else
-            self.class.delete_all!(:id => self.id)
+            self.class.base_class.delete_all!(:id => self.id)
           end
-          self.paranoid_value = self.class.delete_now_value
+          self.paranoid_value = self.class.base_class.delete_now_value
         end
       end
     end
     
     def recover(options={})
       options = {
-                  :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
-                  :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
+                  :recursive => self.class.base_class.paranoid_configuration[:recover_dependent_associations],
+                  :recovery_window => self.class.base_class.paranoid_configuration[:dependent_recovery_window]
                 }.merge(options)
 
       self.class.transaction do
         recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
-        self.update_attributes(self.class.paranoid_column.to_sym => nil)
+        self.update_attributes(self.class.base_class.paranoid_column.to_sym => nil)
       end
     end
 
@@ -157,7 +157,7 @@ module ActsAsParanoid
     
   private
     def paranoid_value=(value)
-      self.send("#{self.class.paranoid_column}=", value)
+      self.send("#{self.class.base_class.paranoid_column}=", value)
     end
     
   end

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.0.5"
+  s.version           = "0.0.6"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Gonçalo Silva"]
   s.email             = ["goncalossilva@gmail.com"]


### PR DESCRIPTION
I encountered errors, when attempting to destroy dependents. It seems ActiveSupport::Callbacks (via run_callbacks) was unable to access the paranoid configuration, etc. I remedied this by adding class.base_class to a number of class calls.

Apologies for not writing a test, but I'm only familiar with Rspec and I'm under deadline. :/

This is the skeleton of what errored out:

```
class Campaign < ActiveRecord::Base
  has_many :titles, :class_name => 'CampaignTitle', :dependent => :destroy
  acts_as_paranoid
end

class CampaignVariation < ActiveRecord::Base
  belongs_to :campaign
  acts_as_paranoid
end

class CampaignTitle < CampaignVariation

end

c = Campaign.new.save
c.titles.create :content => :foo
c.destroy
NoMethodError: You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.[]
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@adaptly_test/gems/rails3_acts_as_paranoid-0.0.5/lib/rails3_acts_as_paranoid.rb:69:in `paranoid_column'
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@adaptly_test/gems/rails3_acts_as_paranoid-0.0.5/lib/rails3_acts_as_paranoid.rb:91:in `paranoid_value'
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@adaptly_test/gems/rails3_acts_as_paranoid-0.0.5/lib/rails3_acts_as_paranoid.rb:107:in `block (2 levels) in destroy'
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@global/gems/activesupport-3.0.4/lib/active_support/callbacks.rb:413:in `_run_destroy_callbacks'
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@global/gems/activesupport-3.0.4/lib/active_support/callbacks.rb:93:in `run_callbacks'
    from /Users/flah/.rvm/gems/ruby-1.9.2-p180@adaptly_test/gems/rails3_acts_as_paranoid-0.0.5/lib/rails3_acts_as_paranoid.rb:106:in `block in destroy'
    ....
```
