### PR TITLE
extending deletion column type to include string type datatable fields

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -34,9 +34,9 @@ module ActsAsParanoid
 		# setting default scope value as per the type
 		#default_scope where("#{paranoid_column_reference} =?", 'IN') # Magic!
 		case paranoid_configuration[:column_type]
-			when "time" then default_scope where("#{paranoid_column_reference} IS ?", nil)
-			when "boolean" then default_scope where("#{paranoid_column_reference} IS ?", nil)
-			when "string" then default_scope where("#{paranoid_column_reference} = ?", 'IN')	
+		when "time" then default_scope where("#{paranoid_column_reference} IS ?", nil)
+		when "boolean" then default_scope where("#{paranoid_column_reference} IS ?", nil)
+		when "string" then default_scope where("#{paranoid_column_reference} = ?", 'IN')	
 		end
 		
 		scope :paranoid_deleted_around_time, lambda {|value, window|
@@ -63,9 +63,9 @@ module ActsAsParanoid
 			
 			#setting unscoped records on basis of type
 			case paranoid_configuration[:column_type]
-				when "string" then self.unscoped.where("#{paranoid_column_reference} != ?", 'IN')
-				when "time" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
-				when "boolean" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+			when "string" then self.unscoped.where("#{paranoid_column_reference} != ?", 'IN')
+			when "time" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+			when "boolean" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
 			end
 		end
 		
@@ -123,6 +123,16 @@ module ActsAsParanoid
 				end
 			end
 		end
+		
+		def delete
+			with_transaction_returning_status do
+				run_callbacks :destroy do
+					self.class.delete_all(:id => self.id)
+					freeze
+				end
+			end
+		end
+		
 		def recover(options={})
 			options = {
 				:recursive => self.class.paranoid_configuration[:recover_dependent_associations],
@@ -133,10 +143,10 @@ module ActsAsParanoid
 				recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 				
 				case paranoid_configuration[:column_type]
-					when "time" then self.update_attributes(self.class.paranoid_column.to_sym => nil )
-					when "boolean" then self.update_attributes(self.class.paranoid_column.to_sym => nil)
+				when "time" then self.update_attributes(self.class.paranoid_column.to_sym => nil )
+				when "boolean" then self.update_attributes(self.class.paranoid_column.to_sym => nil)
 					# adding string type exclusion value	
-					when "string" then self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
+				when "string" then self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
 				end
 				#self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
 			end

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -2,163 +2,182 @@ require 'active_record'
 require 'validations/uniqueness_without_deleted'
 
 module ActsAsParanoid
-  
-  def paranoid?
-    self.included_modules.include?(InstanceMethods)
-  end
-  
-  def validates_as_paranoid
-    extend ParanoidValidations::ClassMethods
-  end
-  
-  def acts_as_paranoid(options = {})
-    raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
-    
-    class_attribute :paranoid_configuration, :paranoid_column_reference
-    
-	# default configuration set to 'exclusion_cd' field with type 'string'
-    self.paranoid_configuration = { :column => "exclusion_cd", :column_type => "string", :recover_dependent_associations => false, :dependent_recovery_window => 5.minutes }.merge(options)
-
-	# extended to accept sting variables
-    raise ArgumentError, "'time' or 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
-
-    self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
-    
-    return if paranoid?
-
-    ActiveRecord::Relation.class_eval do
-      alias_method :delete_all!, :delete_all
-      alias_method :destroy!, :destroy
-    end
-    
-	# setting default scope value as 'IN'
-    default_scope where("#{paranoid_column_reference} =?", 'IN') # Magic!
-    
-    scope :paranoid_deleted_around_time, lambda {|value, window|
-        self.where("#{self.class.paranoid_column} > ? AND #{self.class.paranoid_column} < ?", (value - window), (value + window))
 	
-      
-    }
-    
-    include InstanceMethods
-    extend ClassMethods
-  end
-
-  module ClassMethods
-    
-public
-
-    def with_deleted
-      self.unscoped.reload
-    end
-
-    def only_deleted
-		# unscoped records  identified 
-      self.unscoped.where("#{paranoid_column_reference} != ?", 'IN')
-    end
-
-    def delete_all!(conditions = nil)
-      self.unscoped.delete_all!(conditions)
-    end
-
-    def delete_all(conditions = nil)
-      update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
-    end
-
-    def paranoid_column
-      paranoid_configuration[:column].to_sym
-    end
-
-    def paranoid_column_type
-      paranoid_configuration[:column_type].to_sym
-    end
-
-    def dependent_associations
-      self.reflect_on_all_associations.select {|a| [:delete_all, :destroy].include?(a.options[:dependent]) }
-    end
-  
-    def delete_now_value
-      case paranoid_configuration[:column_type]
-        when "time" then Time.now
-        when "boolean" then true
-		# adding string type exclusion value	
-		when "string" then :OUT
-      end
-    end
-  end
-  
-  module InstanceMethods
-    
-    def paranoid_value
-      self.send(self.class.paranoid_column)
-    end
-  
-    def destroy!
-      with_transaction_returning_status do
-        run_callbacks :destroy do
-          self.class.delete_all!(:id => self.id)
-          self.paranoid_value = self.class.delete_now_value
-          freeze
-        end
-      end
-    end
-
-    def destroy
-      with_transaction_returning_status do
-        run_callbacks :destroy do
-            self.class.delete_all(:id => self.id)
-        end
-      end
-    end
-    def recover(options={})
-      options = {
-                  :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
-                  :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
-                }.merge(options)
-
-      self.class.transaction do
-        recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
-
-        self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
-      end
-    
-    end
-
-    def recover_dependent_associations(window, options)
-      self.class.dependent_associations.each do |association|
-        if association.collection? && self.send(association.name).paranoid?
-          self.send(association.name).unscoped do
-            self.send(association.name).paranoid_deleted_around_time(paranoid_value, window).each do |object|
-              object.recover(options) if object.respond_to?(:recover)
-            end
-          end
-        elsif association.macro == :has_one && association.klass.paranoid?
-          association.klass.unscoped do
-            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
-            object.recover(options) if object && object.respond_to?(:recover)
-          end
-        elsif association.klass.paranoid?
-          association.klass.unscoped do
-            id = self.send(association.primary_key_name)
-            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).find_by_id(id)
-            object.recover(options) if object && object.respond_to?(:recover)
-          end
-        end
-      end
-    end
-
-    def deleted?
-      !paranoid_value.nil?
-    end
-    alias_method :destroyed?, :deleted?
-    
-  private
-    def paranoid_value=(value)
-      self.send("#{self.class.paranoid_column}=", value)
-    end
-    
-  end
-  
+	def paranoid?
+		self.included_modules.include?(InstanceMethods)
+	end
+	
+	def validates_as_paranoid
+		extend ParanoidValidations::ClassMethods
+	end
+	
+	def acts_as_paranoid(options = {})
+		raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
+		
+		class_attribute :paranoid_configuration, :paranoid_column_reference
+		
+		# default configuration set to 'exclusion_cd' field with type 'string'
+		self.paranoid_configuration = { :column => "exclusion_cd", :column_type => "string", :recover_dependent_associations => false, :dependent_recovery_window => 5.minutes }.merge(options)
+		
+		# extended to accept sting variables
+		raise ArgumentError, "'time' or 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
+		
+		self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
+		
+		return if paranoid?
+		
+		ActiveRecord::Relation.class_eval do
+			alias_method :delete_all!, :delete_all
+			alias_method :destroy!, :destroy
+		end
+		
+		# setting default scope value as per the type
+		#default_scope where("#{paranoid_column_reference} =?", 'IN') # Magic!
+		case paranoid_configuration[:column_type]
+			when "time" then default_scope where("#{paranoid_column_reference} IS ?", nil)
+			when "boolean" then default_scope where("#{paranoid_column_reference} IS ?", nil)
+			when "string" then default_scope where("#{paranoid_column_reference} = ?", 'IN')	
+		end
+		
+		scope :paranoid_deleted_around_time, lambda {|value, window|
+			self.where("#{self.class.paranoid_column} > ? AND #{self.class.paranoid_column} < ?", (value - window), (value + window))
+			
+			
+		}
+		
+		include InstanceMethods
+		extend ClassMethods
+	end
+	
+	module ClassMethods
+		
+		public
+		
+		def with_deleted
+			self.unscoped.reload
+		end
+		
+		def only_deleted
+			# unscoped records  identified 
+			#self.unscoped.where("#{paranoid_column_reference} != ?", 'IN')
+			
+			#setting unscoped records on basis of type
+			case paranoid_configuration[:column_type]
+				when "string" then self.unscoped.where("#{paranoid_column_reference} != ?", 'IN')
+				when "time" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+				when "boolean" then self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+			end
+		end
+		
+		def delete_all!(conditions = nil)
+			self.unscoped.delete_all!(conditions)
+		end
+		
+		def delete_all(conditions = nil)
+			update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
+		end
+		
+		def paranoid_column
+			paranoid_configuration[:column].to_sym
+		end
+		
+		def paranoid_column_type
+			paranoid_configuration[:column_type].to_sym
+		end
+		
+		def dependent_associations
+			self.reflect_on_all_associations.select {|a| [:delete_all, :destroy].include?(a.options[:dependent]) }
+		end
+		
+		def delete_now_value
+			case paranoid_configuration[:column_type]
+			when "time" then Time.now
+			when "boolean" then true
+				# adding string type exclusion value	
+			when "string" then :OUT
+			end
+		end
+	end
+	
+	module InstanceMethods
+		
+		def paranoid_value
+			self.send(self.class.paranoid_column)
+		end
+		
+		def destroy!
+			with_transaction_returning_status do
+				run_callbacks :destroy do
+					self.class.delete_all!(:id => self.id)
+					self.paranoid_value = self.class.delete_now_value
+					freeze
+				end
+			end
+		end
+		
+		def destroy
+			with_transaction_returning_status do
+				run_callbacks :destroy do
+					self.class.delete_all(:id => self.id)
+					freeze
+				end
+			end
+		end
+		def recover(options={})
+			options = {
+				:recursive => self.class.paranoid_configuration[:recover_dependent_associations],
+				:recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
+			}.merge(options)
+			
+			self.class.transaction do
+				recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
+				
+				case paranoid_configuration[:column_type]
+					when "time" then self.update_attributes(self.class.paranoid_column.to_sym => nil )
+					when "boolean" then self.update_attributes(self.class.paranoid_column.to_sym => nil)
+					# adding string type exclusion value	
+					when "string" then self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
+				end
+				#self.update_attributes(self.class.paranoid_column.to_sym => 'IN')
+			end
+			
+		end
+		
+		def recover_dependent_associations(window, options)
+			self.class.dependent_associations.each do |association|
+				if association.collection? && self.send(association.name).paranoid?
+					self.send(association.name).unscoped do
+						self.send(association.name).paranoid_deleted_around_time(paranoid_value, window).each do |object|
+							object.recover(options) if object.respond_to?(:recover)
+						end
+					end
+				elsif association.macro == :has_one && association.klass.paranoid?
+					association.klass.unscoped do
+						object = association.klass.paranoid_deleted_around_time(paranoid_value, window).send('find_by_'+association.primary_key_name, self.id)
+						object.recover(options) if object && object.respond_to?(:recover)
+					end
+				elsif association.klass.paranoid?
+					association.klass.unscoped do
+						id = self.send(association.primary_key_name)
+						object = association.klass.paranoid_deleted_around_time(paranoid_value, window).find_by_id(id)
+						object.recover(options) if object && object.respond_to?(:recover)
+					end
+				end
+			end
+		end
+		
+		def deleted?
+			!paranoid_value.nil?
+		end
+		alias_method :destroyed?, :deleted?
+		
+		private
+		def paranoid_value=(value)
+			self.send("#{self.class.paranoid_column}=", value)
+		end
+		
+	end
+	
 end
 
 # Extend ActiveRecord's functionality

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/array/wrap'
 
+# comment
 module ParanoidValidations
   class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
     def validate_each(record, attribute, value)

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
-#class ParanoidTest < Test::Unit::TestCase
-  class ParanoidTest < ActionController::TestCase
+class ParanoidTest < Test::Unit::TestCase
   #fixtures :Posts
 
 

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -1,242 +1,46 @@
 require 'test_helper'
 
-class ParanoidBaseTest < ActiveSupport::TestCase
-  def assert_empty(collection)
-    assert(collection.respond_to?(:empty?) && collection.empty?)
-  end
-  
-  def setup
-    setup_db
+class ParanoidTest < Test::Unit::TestCase
+  fixtures :Blog
 
-    ["paranoid", "really paranoid", "extremely paranoid"].each do |name|
-      ParanoidTime.create! :name => name
-      ParanoidBoolean.create! :name => name
-    end
-
-    NotParanoid.create! :name => "no paranoid goals"
-    ParanoidWithCallback.create! :name => 'paranoid with callbacks'
+  def test_should_recognize_with_exclusion_cd
+    assert_equal [2, 4], Blog.find(:all, :conditions => ["exclusion_cd = 'IN'"]).collect { |w| w.id }
+    assert_equal [1, 3], Blog.find(:all, :conditions => ["exclusion_cd = 'OUT'"]).collect { |w| w.id }
   end
 
-  def teardown
-    teardown_db
-  end
-end
-
-class ParanoidTest < ParanoidBaseTest
-  def test_fake_removal
-    assert_equal 3, ParanoidTime.count
-    assert_equal 3, ParanoidBoolean.count
-
-    ParanoidTime.first.destroy
-    ParanoidBoolean.delete_all("name = 'paranoid' OR name = 'really paranoid'")
-    assert_equal 2, ParanoidTime.count
-    assert_equal 1, ParanoidBoolean.count
-    assert_equal 1, ParanoidTime.only_deleted.count 
-    assert_equal 2, ParanoidBoolean.only_deleted.count
-    assert_equal 3, ParanoidTime.with_deleted.count
-    assert_equal 3, ParanoidBoolean.with_deleted.count
+  def test_should_recognize_with_only_deleted
+    assert_equal [1, 3], Blog.only_deleted.collect { |w| w.id }
   end
 
-  def test_real_removal
-    ParanoidTime.first.destroy!
-    ParanoidBoolean.delete_all!("name = 'extremely paranoid' OR name = 'really paranoid'")
-    assert_equal 2, ParanoidTime.count
-    assert_equal 1, ParanoidBoolean.count
-    assert_equal 2, ParanoidTime.with_deleted.count
-    assert_equal 1, ParanoidBoolean.with_deleted.count
-    assert_equal 0, ParanoidBoolean.only_deleted.count
-    assert_equal 0, ParanoidTime.only_deleted.count
-
-    ParanoidTime.first.destroy
-    ParanoidTime.only_deleted.first.destroy
-    assert_equal 0, ParanoidTime.only_deleted.count
-
-    ParanoidTime.delete_all!
-    assert_empty ParanoidTime.all
-    assert_empty ParanoidTime.with_deleted.all    
+  def test_is_deleted
+    assert_equal false, Blog.is_deleted?(2)
+    assert_equal true, Blog.is_deleted?(3)
   end
 
-  def test_paranoid_scope
-    assert_raise(NoMethodError) { NotParanoid.delete_all! }
-    assert_raise(NoMethodError) { NotParanoid.first.destroy! }
-    assert_raise(NoMethodError) { NotParanoid.with_deleted }
-    assert_raise(NoMethodError) { NotParanoid.only_deleted }    
+  def test_should_count_with_deleted
+    assert_equal 2, Blog.count
+    assert_equal 4, Blog.count_with_deleted
+    assert_equal 2, Blog.count_only_deleted
   end
 
-  def test_recovery
-    assert_equal 3, ParanoidBoolean.count
-    ParanoidBoolean.first.destroy
-    assert_equal 2, ParanoidBoolean.count
-    ParanoidBoolean.only_deleted.first.recover
-    assert_equal 3, ParanoidBoolean.count
+  def test_should_set_deleted_at
+    assert_equal 1, Blog.count
+    Blog(:blog_1).destroy
+    assert_equal 0, Blog.count
+    assert_equal 2, Blog.calculate_with_deleted(:count, :all)
   end
 
-  def setup_recursive_recovery_tests
-    @paranoid_time_object = ParanoidTime.first
-
-    @paranoid_boolean_count = ParanoidBoolean.count
-
-    assert_equal 0, ParanoidHasManyDependant.count
-    assert_equal 0, ParanoidBelongsDependant.count
-
-    (1..3).each do |i|
-      has_many_object = @paranoid_time_object.paranoid_has_many_dependants.create(:name => "has_many_#{i}")
-      has_many_object.create_paranoid_belongs_dependant(:name => "belongs_to_#{i}")
-      has_many_object.save
-
-      paranoid_boolean = @paranoid_time_object.paranoid_booleans.create(:name => "boolean_#{i}")
-      paranoid_boolean.create_paranoid_has_one_dependant(:name => "has_one_#{i}")
-      paranoid_boolean.save
-
-      @paranoid_time_object.not_paranoids.create(:name => "not_paranoid_a#{i}")
-
-    end
-
-    @paranoid_time_object.create_not_paranoid(:name => "not_paranoid_belongs_to")
-
-    @paranoid_time_object.create_has_one_not_paranoid(:name => "has_one_not_paranoid")
-
-    assert_equal 3, ParanoidTime.count
-    assert_equal 3, ParanoidHasManyDependant.count
-    assert_equal 3, ParanoidBelongsDependant.count
-    assert_equal 3, ParanoidHasOneDependant.count
-    assert_equal 5, NotParanoid.count
-    assert_equal 1, HasOneNotParanoid.count
-    assert_equal @paranoid_boolean_count + 3, ParanoidBoolean.count
-
-    @paranoid_time_object.destroy
-    @paranoid_time_object.reload
-
-    assert_equal 2, ParanoidTime.count
-    assert_equal 0, ParanoidHasManyDependant.count
-    assert_equal 0, ParanoidBelongsDependant.count
-    assert_equal 0, ParanoidHasOneDependant.count
-
-    assert_equal 1, NotParanoid.count
-    assert_equal 0, HasOneNotParanoid.count
-    assert_equal @paranoid_boolean_count, ParanoidBoolean.count
-  end
-
-  def test_recursive_recovery
-    setup_recursive_recovery_tests
-
-    @paranoid_time_object.recover(:recursive => true)
-
-    assert_equal 3, ParanoidTime.count
-    assert_equal 3, ParanoidHasManyDependant.count
-    assert_equal 3, ParanoidBelongsDependant.count
-    assert_equal 3, ParanoidHasOneDependant.count
-    assert_equal 1, NotParanoid.count
-    assert_equal 0, HasOneNotParanoid.count
-    assert_equal @paranoid_boolean_count + 3, ParanoidBoolean.count
-  end
-
-  def test_non_recursive_recovery
-    setup_recursive_recovery_tests
-
-    @paranoid_time_object.recover(:recursive => false)
-
-    assert_equal 3, ParanoidTime.count
-    assert_equal 0, ParanoidHasManyDependant.count
-    assert_equal 0, ParanoidBelongsDependant.count
-    assert_equal 0, ParanoidHasOneDependant.count
-    assert_equal 1, NotParanoid.count
-    assert_equal 0, HasOneNotParanoid.count
-    assert_equal @paranoid_boolean_count, ParanoidBoolean.count
-  end
-
-  def test_deleted?
-    ParanoidTime.first.destroy
-    assert ParanoidTime.with_deleted.first.deleted?
-  end
-  
-  def test_paranoid_destroy_callbacks    
-    @paranoid_with_callback = ParanoidWithCallback.first
-    ParanoidWithCallback.transaction do
-      @paranoid_with_callback.destroy
-    end
-    
-    assert @paranoid_with_callback.called_before_destroy
-    assert @paranoid_with_callback.called_after_destroy
-    assert @paranoid_with_callback.called_after_commit_on_destroy
-  end
-  
-  def test_hard_destroy_callbacks
-    @paranoid_with_callback = ParanoidWithCallback.first
-    
-    ParanoidWithCallback.transaction do
-      @paranoid_with_callback.destroy!
-    end
-    
-    assert @paranoid_with_callback.called_before_destroy
-    assert @paranoid_with_callback.called_after_destroy
-    assert @paranoid_with_callback.called_after_commit_on_destroy
+  def test_should_destroy
+    assert_equal 2, Blog.count
+    Blog(:blog_1).destroy!
+    assert_equal 1, Blog.count
+    assert_equal 3, Blog.count_only_deleted
+    assert_equal 4, Blog.cont_with_deleted
   end
 end
 
-class ValidatesUniquenessTest < ParanoidBaseTest
-  def test_should_include_deleted_by_default
-    ParanoidTime.new(:name => 'paranoid').tap do |record|
-      assert !record.valid?
-      ParanoidTime.first.destroy
-      assert !record.valid?
-      ParanoidTime.only_deleted.first.destroy!
-      assert record.valid?
-    end
-  end
-
-  def test_should_validate_without_deleted
-    ParanoidBoolean.new(:name => 'paranoid').tap do |record|
-      ParanoidBoolean.first.destroy
-      assert record.valid?
-      ParanoidBoolean.only_deleted.first.destroy!
-      assert record.valid?
-    end
-  end
-end
-
-class AssociationsTest < ParanoidBaseTest  
-  def test_removal_with_associations
-    # This test shows that the current implementation doesn't handle
-    # assciation deletion correctly (when hard deleting via parent-object)
-    paranoid_company_1 = ParanoidDestroyCompany.create! :name => "ParanoidDestroyCompany #1"
-    paranoid_company_2 = ParanoidDeleteCompany.create! :name => "ParanoidDestroyCompany #1"
-    paranoid_company_1.paranoid_products.create! :name => "ParanoidProduct #1"
-    paranoid_company_2.paranoid_products.create! :name => "ParanoidProduct #2"
-    
-    assert_equal 1, ParanoidDestroyCompany.count
-    assert_equal 1, ParanoidDeleteCompany.count
-    assert_equal 2, ParanoidProduct.count
-
-    ParanoidDestroyCompany.first.destroy
-    assert_equal 0, ParanoidDestroyCompany.count
-    assert_equal 1, ParanoidProduct.count
-    assert_equal 1, ParanoidDestroyCompany.with_deleted.count
-    assert_equal 2, ParanoidProduct.with_deleted.count
-	
-    ParanoidDestroyCompany.with_deleted.first.destroy!
-    assert_equal 0, ParanoidDestroyCompany.count
-    assert_equal 1, ParanoidProduct.count
-    assert_equal 0, ParanoidDestroyCompany.with_deleted.count
-    assert_equal 1, ParanoidProduct.with_deleted.count
-    
-    ParanoidDeleteCompany.with_deleted.first.destroy!
-    assert_equal 0, ParanoidDeleteCompany.count
-    assert_equal 0, ParanoidProduct.count
-    assert_equal 0, ParanoidDeleteCompany.with_deleted.count
-    assert_equal 0, ParanoidProduct.with_deleted.count
-  end
-end
-
-class InheritanceTest < ParanoidBaseTest
-  def test_destroy_dependents_with_inheritance
-    has_many_inherited_super_paranoidz = HasManyInheritedSuperParanoidz.new
-    has_many_inherited_super_paranoidz.save
-    has_many_inherited_super_paranoidz.super_paranoidz.create
-    assert_nothing_raised(NoMethodError) { has_many_inherited_super_paranoidz.destroy }
-  end
-  
-  def test_class_instance_variables_are_inherited
-    assert_nothing_raised(ActiveRecord::StatementInvalid) { InheritedParanoid.paranoid_column }
+class Array
+  def ids
+    collect &:id
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,109 +10,41 @@ $:.unshift "#{File.dirname(__FILE__)}/../lib/validations"
 
 require 'init'
 
-ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
+ActiveRecord::Base.establish_connection(:adapter => "mysql2", :database => ":memory:")
 
 def setup_db
   ActiveRecord::Schema.define(:version => 1) do
-    create_table :paranoid_times do |t|
-      t.string    :name
-      t.datetime  :deleted_at
-      t.integer   :paranoid_belongs_dependant_id
-      t.integer   :not_paranoid_id
+    create_table "blogs", :force => true do |t|
+    t.string   "title"
+    t.string   "body"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "user_id"
+    t.string   "exclusion_cd"
+    t.time     "deleted_at"
+  end
 
-      t.timestamps
-    end
+  create_table "comments", :force => true do |t|
+    t.string   "comment"
+    t.string   "author"
+    t.integer  "blogs_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
-    create_table :paranoid_booleans do |t|
-      t.string    :name
-      t.boolean   :is_deleted
-      t.integer   :paranoid_time_id
-
-      t.timestamps
-    end
-
-    create_table :not_paranoids do |t|
-      t.string    :name
-      t.integer   :paranoid_time_id
-      
-      t.timestamps
-    end
-
-    create_table :has_one_not_paranoids do |t|
-      t.string    :name
-      t.integer   :paranoid_time_id
-
-      t.timestamps
-    end
-
-    create_table :paranoid_has_many_dependants do |t|
-      t.string    :name
-      t.datetime  :deleted_at
-      t.integer   :paranoid_time_id
-      t.integer   :paranoid_belongs_dependant_id
-
-      t.timestamps
-    end
-
-    create_table :paranoid_belongs_dependants do |t|
-      t.string    :name
-      t.datetime  :deleted_at
-
-      t.timestamps
-    end
-
-    create_table :paranoid_has_one_dependants do |t|
-      t.string    :name
-      t.datetime  :deleted_at
-      t.integer   :paranoid_boolean_id
-
-      t.timestamps
-    end
-    
-    create_table :paranoid_with_callbacks do |t|
-      t.string    :name
-      t.datetime  :deleted_at
-      
-      t.timestamps
-    end
-
-    create_table :paranoid_destroy_companies do |t|
-      t.string :name
-      t.datetime :deleted_at
-      
-      t.timestamps
-    end
-    
-    create_table :paranoid_delete_companies do |t|
-      t.string :name
-      t.datetime :deleted_at
-      
-      t.timestamps
-    end
-    
-    create_table :paranoid_products do |t|
-      t.integer :paranoid_destroy_company_id
-      t.integer :paranoid_delete_company_id
-      t.string :name
-      t.datetime :deleted_at
-      
-      t.timestamps
-    end
-    
-    create_table :super_paranoids do |t|
-      t.string :type
-      t.references :has_many_inherited_super_paranoidz
-      t.datetime :deleted_at
-      
-      t.timestamps
-    end
-    
-    create_table :has_many_inherited_super_paranoidzs do |t|
-      t.references :super_paranoidz
-      t.datetime :deleted_at
-      
-      t.timestamps
-    end
+  create_table "users", :force => true do |t|
+    t.string   "name"
+    t.string   "email"
+    t.string   "userid"
+    t.string   "pwd"
+    t.integer  "no_of_blogs"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "password_salt"
+    t.string   "password_hash"
+    t.string   "exclusion_cd"
+    t.time     "deleted_at"
+  end
   end
 end
 
@@ -122,109 +54,8 @@ def teardown_db
   end
 end
 
-class ParanoidTime < ActiveRecord::Base
-  acts_as_paranoid
-  validates_uniqueness_of :name
 
-  has_many :paranoid_has_many_dependants, :dependent => :destroy
-  has_many :paranoid_booleans, :dependent => :destroy
-  has_many :not_paranoids, :dependent => :delete_all
 
-  has_one :has_one_not_paranoid, :dependent => :destroy
-
-  belongs_to :not_paranoid, :dependent => :destroy
-end
-
-class ParanoidBoolean < ActiveRecord::Base
-  acts_as_paranoid :column_type => "boolean", :column => "is_deleted"
-  validates_as_paranoid
-  validates_uniqueness_of_without_deleted :name
-
-  belongs_to :paranoid_time
-  has_one :paranoid_has_one_dependant, :dependent => :destroy
-end
-
-class NotParanoid < ActiveRecord::Base
-end
-
-class HasOneNotParanoid < ActiveRecord::Base
-end
-
-class ParanoidHasManyDependant < ActiveRecord::Base
-  acts_as_paranoid
-  belongs_to :paranoid_time
-
-  belongs_to :paranoid_belongs_dependant, :dependent => :destroy
-end
-
-class ParanoidBelongsDependant < ActiveRecord::Base
-  acts_as_paranoid
-
-  has_many :paranoid_has_many_dependants
-end
-
-class ParanoidHasOneDependant < ActiveRecord::Base
-  acts_as_paranoid
-
-  belongs_to :paranoid_boolean
-end
-
-class ParanoidWithCallback < ActiveRecord::Base
-  acts_as_paranoid
-  
-  attr_accessor :called_before_destroy, :called_after_destroy, :called_after_commit_on_destroy
-  
-  before_destroy :call_me_before_destroy
-  after_destroy :call_me_after_destroy
-  
-  after_commit :call_me_after_commit_on_destroy, :on => :destroy
-  
-  def initialize(*attrs)
-    @called_before_destroy = @called_after_destroy = @called_after_commit_on_destroy = false
-    super(*attrs)
-  end
-  
-  def call_me_before_destroy
-    @called_before_destroy = true
-  end
-  
-  def call_me_after_destroy
-    @called_after_destroy = true
-  end
-  
-  def call_me_after_commit_on_destroy
-    @called_after_commit_on_destroy = true
-  end
-end
-
-class ParanoidDestroyCompany < ActiveRecord::Base
-  acts_as_paranoid
-  validates :name, :presence => true
-  has_many :paranoid_products, :dependent => :destroy
-end
-
-class ParanoidDeleteCompany < ActiveRecord::Base
-  acts_as_paranoid
-  validates :name, :presence => true
-  has_many :paranoid_products, :dependent => :delete_all
-end
-
-class ParanoidProduct < ActiveRecord::Base
-  acts_as_paranoid
-  belongs_to :paranoid_destroy_company
-  belongs_to :paranoid_delete_company
-  validates_presence_of :name
-end
-
-class SuperParanoid < ActiveRecord::Base
-  acts_as_paranoid
-  belongs_to :has_many_inherited_super_paranoidz
-end
-
-class HasManyInheritedSuperParanoidz < ActiveRecord::Base
-  has_many :super_paranoidz, :class_name => "InheritedParanoid", :dependent => :destroy
-end
-
-class InheritedParanoid < SuperParanoid
-  acts_as_paranoid
+class Blog < ActiveRecord::Base
+	acts_as_paranoid
 end


### PR DESCRIPTION
I had made changes to the gem to fulfill the requirements of my project, which were to have the deletion column in datatable as a string field. This worked for me , hope it can be helpfull to others too.
