### PR TITLE
remove reload after unscoping

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -48,7 +48,7 @@ module ActsAsParanoid
   module ClassMethods
     
     def with_deleted
-      self.unscoped.reload
+      self.unscoped
     end
 
     def only_deleted


### PR DESCRIPTION
With reload after unscoping causes query like this:

Model.with_deleted.find(1)

select model.\* from model;
select model.\* from model where id = 1;

This is unacceptable with large tables with which this is meant to be used.
