### PR TITLE
add new callbacks to active record for recovery of paranoid models

### DIFF
--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -172,6 +172,22 @@ class ParanoidTest < ParanoidBaseTest
     assert @paranoid_with_callback.called_after_destroy
     assert @paranoid_with_callback.called_after_commit_on_destroy
   end
+
+  def test_recovery_callbacks
+    @paranoid_with_callback = ParanoidWithCallback.first
+
+    ParanoidWithCallback.transaction do
+      @paranoid_with_callback.destroy
+
+      assert_nil @paranoid_with_callback.called_before_recover
+      assert_nil @paranoid_with_callback.called_after_recover
+
+      @paranoid_with_callback.recover
+    end
+
+      assert @paranoid_with_callback.called_before_recover
+      assert @paranoid_with_callback.called_after_recover    
+  end
 end
 
 class ValidatesUniquenessTest < ParanoidBaseTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -173,11 +173,15 @@ class ParanoidWithCallback < ActiveRecord::Base
   acts_as_paranoid
   
   attr_accessor :called_before_destroy, :called_after_destroy, :called_after_commit_on_destroy
+  attr_accessor :called_before_recover, :called_after_recover
   
   before_destroy :call_me_before_destroy
   after_destroy :call_me_after_destroy
   
   after_commit :call_me_after_commit_on_destroy, :on => :destroy
+
+  before_recover :call_me_before_recover
+  after_recover :call_me_after_recover
   
   def initialize(*attrs)
     @called_before_destroy = @called_after_destroy = @called_after_commit_on_destroy = false
@@ -194,6 +198,14 @@ class ParanoidWithCallback < ActiveRecord::Base
   
   def call_me_after_commit_on_destroy
     @called_after_commit_on_destroy = true
+  end
+
+  def call_me_before_recover
+    @called_before_recover = true
+  end
+
+  def call_me_after_recover
+    @called_after_recover = true
   end
 end
 


### PR DESCRIPTION
As the title implies I've added ActiveRecord style callbacks for the recovery phase of the model's lifecycle
