### PR TITLE
Add support for using ActiveRecord::Observer

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -178,3 +178,6 @@ end
 
 # Extend ActiveRecord's functionality
 ActiveRecord::Base.send :extend, ActsAsParanoid
+
+# Push the recover callback onto the activerecord callback list
+ActiveRecord::Callbacks::CALLBACKS.push(:before_recover, :after_recover)

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -15,6 +15,8 @@ class ParanoidBaseTest < ActiveSupport::TestCase
 
     NotParanoid.create! :name => "no paranoid goals"
     ParanoidWithCallback.create! :name => 'paranoid with callbacks'
+
+    ParanoidObserver.instance.reset
   end
 
   def teardown
@@ -254,5 +256,21 @@ class InheritanceTest < ParanoidBaseTest
   
   def test_class_instance_variables_are_inherited
     assert_nothing_raised(ActiveRecord::StatementInvalid) { InheritedParanoid.paranoid_column }
+  end
+end
+
+class ParanoidObserverTest < ParanoidBaseTest
+
+  def test_called_observer_methods
+    @subject = ParanoidWithCallback.new
+    @subject.save
+
+    assert_nil ParanoidObserver.instance.called_before_recover
+    assert_nil ParanoidObserver.instance.called_after_recover
+    
+    ParanoidWithCallback.find(@subject.id).recover
+
+    assert_equal @subject, ParanoidObserver.instance.called_before_recover
+    assert_equal @subject, ParanoidObserver.instance.called_after_recover
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -240,3 +240,24 @@ end
 class InheritedParanoid < SuperParanoid
   acts_as_paranoid
 end
+
+class ParanoidObserver < ActiveRecord::Observer
+  observe :paranoid_with_callback
+
+  attr_accessor :called_before_recover, :called_after_recover
+
+  def before_recover(paranoid_object)
+    self.called_before_recover = paranoid_object
+  end
+
+  def after_recover(paranoid_object)
+    self.called_after_recover = paranoid_object
+  end
+
+  def reset
+    self.called_before_recover = nil
+    self.called_after_recover = nil
+  end
+end
+
+ParanoidWithCallback.add_observer(ParanoidObserver.instance)


### PR DESCRIPTION
added code to support observation of paranoid models with ActiveRecord::Observer for the new before_recover and after_recover callbacks
