### PR TITLE
Special characters throw off bundler

### DIFF
--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
   s.version           = "0.1"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Gonçalo Silva"]
+  s.authors           = ["Gonzalo Silva"]
   s.email             = ["goncalossilva@gmail.com"]
   s.homepage          = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
   s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."


### PR DESCRIPTION
If the server doesn't support special characters it will crash bundle install (Heroku in this case).
