### PR TITLE
define foreign_key as an alias of primary_key_name to maintain backward compatibility

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -31,6 +31,10 @@ module ActsAsParanoid
       alias_method :destroy!, :destroy
     end
     
+    ActiveRecord::Reflection::AssociationReflection.class_eval do
+      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
+    end
+
     # Magic!
     default_scope where("#{paranoid_column_reference} IS ?", nil)
     


### PR DESCRIPTION
define foreign_key as an alias of primary_key_name to maintain backward compatibility

Method primary_key_name is now deprecated and the replacement foreign_key is newly
introduced in active_record 3.1.0. While the new method should be used for rails 3.1.x
or later, the old one is still required for rails 3.0.x.
