### PR TITLE
Changes to rails3_acts_as_paranoid for Rails 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem "rails3_acts_as_paranoid", :path => File.expand_path("..", __FILE__)
 
 # Development dependencies 
 gem "rake"
-gem "activesupport", "~>3.0"
+gem "activesupport", "~>3.1"
 gem "sqlite3-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,38 @@
 PATH
   remote: .
   specs:
-    rails3_acts_as_paranoid (0.1.1)
-      activerecord (~> 3.0)
+    rails3_acts_as_paranoid (0.1.1.2)
+      activerecord (~> 3.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.9)
-      activesupport (= 3.0.9)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activerecord (3.0.9)
-      activemodel (= 3.0.9)
-      activesupport (= 3.0.9)
-      arel (~> 2.0.10)
-      tzinfo (~> 0.3.23)
-    activesupport (3.0.9)
-    arel (2.0.10)
-    builder (2.1.2)
-    i18n (0.5.0)
-    rake (0.8.7)
-    sqlite3 (1.3.3)
+    activemodel (3.1.3)
+      activesupport (= 3.1.3)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activerecord (3.1.3)
+      activemodel (= 3.1.3)
+      activesupport (= 3.1.3)
+      arel (~> 2.2.1)
+      tzinfo (~> 0.3.29)
+    activesupport (3.1.3)
+      multi_json (~> 1.0)
+    arel (2.2.1)
+    builder (3.0.0)
+    i18n (0.6.0)
+    multi_json (1.0.4)
+    rake (0.9.2.2)
+    sqlite3 (1.3.5)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
-    tzinfo (0.3.29)
+    tzinfo (0.3.31)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (~> 3.1)
   rails3_acts_as_paranoid!
   rake
   sqlite3-ruby

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -31,10 +31,6 @@ module ActsAsParanoid
       alias_method :destroy!, :destroy
     end
     
-    ActiveRecord::Reflection::AssociationReflection.class_eval do
-      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
-    end
-
     # Magic!
     default_scope where("#{paranoid_column_reference} IS ?", nil)
     

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -9,7 +9,8 @@ module ParanoidValidations
         value = YAML.dump value
       end
 
-      sql, params = build_relation(finder_class, record.class.quoted_table_name, attribute, value)
+      table = Arel::Table.new(record.class.table_name)
+      sql, params = build_relation(finder_class, table, attribute, value)
 
       # This is the only changed line from the base class version - it does finder_class.unscoped
       relation = finder_class.where(sql, *params)

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -9,7 +9,7 @@ module ParanoidValidations
         value = YAML.dump value
       end
 
-      sql, params = mount_sql_and_params(finder_class, record.class.quoted_table_name, attribute, value)
+      sql, params = build_relation(finder_class, record.class.quoted_table_name, attribute, value)
 
       # This is the only changed line from the base class version - it does finder_class.unscoped
       relation = finder_class.where(sql, *params)

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -5,13 +5,13 @@ Gem::Specification.new do |s|
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]
   s.homepage          = "https://github.com/softcraft-development/rails3_acts_as_paranoid"
-  s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
-  s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
+  s.summary           = "Active Record (>=3.1) plugin which allows you to hide and restore records without actually deleting them."
+  s.description       = "Active Record (>=3.1) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name
 
   s.required_rubygems_version = ">= 1.3.6"
   
-  s.add_dependency "activerecord", "~> 3.0"
+  s.add_dependency "activerecord", "~> 3.1"
 
   s.files        = Dir["{lib}/**/*.rb", "LICENSE", "*.markdown"]
 end

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1.1"
+  s.version           = "0.1.1.2"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1"
+  s.version           = "0.1.1.1"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Goncalo Silva"]
-  s.email             = ["goncalossilva@gmail.com"]
-  s.homepage          = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
+  s.authors           = ["Goncalo Silva", "Craig Walker"]
+  s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]
+  s.homepage          = "https://github.com/softcraft-development/rails3_acts_as_paranoid"
   s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
   s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name


### PR DESCRIPTION
I'm hacking around in rails3_acts_as_paranoid. In the process of making my own changes (which I hope to fill you in on later), I found the errors (mentioned [here](https://github.com/goncalossilva/rails3_acts_as_paranoid/issues/40)) caused by using the Rails 3.1 version of ActiveRecord... and managed to fix them.

There's only 3 changes of real importance:
- Rename the call in uniqueness_without_deleted.rb from mount_sql_and_params to build_relation
- In the same call, pass an Arel::Table instead of a String table name.
- Remove the aliasing of primary_key_name to foreign_key in ActiveRecord::Reflection::AssociationReflection

Feel free to ignore/revert my changes to the Gemspec; those are mostly for my own internal purpose.

Hope this helps,

Craig
