### PR TITLE
Add :with_deleted option to belongs_to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*~
 pkg
 .bundle
+.idea

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -4,7 +4,7 @@ class ParanoidBaseTest < ActiveSupport::TestCase
   def assert_empty(collection)
     assert(collection.respond_to?(:empty?) && collection.empty?)
   end
-  
+
   def setup
     setup_db
 
@@ -263,6 +263,20 @@ class AssociationsTest < ParanoidBaseTest
     assert_equal 0, ParanoidDeleteCompany.with_deleted.count
     assert_equal 0, ParanoidProduct.with_deleted.count
   end
+
+  def test_paranoid_belongs_to
+    paranoid_time_object = ParanoidTime.first
+    has_many_object = paranoid_time_object.paranoid_has_many_dependants.create(:name => "has_many")
+
+    assert has_many_object.paranoid_time
+    assert has_many_object.paranoid_time_with_deleted
+
+    paranoid_time_object.destroy
+
+    assert_nil has_many_object.paranoid_time(true)
+    assert has_many_object.paranoid_time_with_deleted(true)
+  end
+
 end
 
 class InheritanceTest < ParanoidBaseTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -162,6 +162,7 @@ end
 class ParanoidHasManyDependant < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_time
+  belongs_to :paranoid_time_with_deleted, :class_name => 'ParanoidTime', :foreign_key => :paranoid_time_id, :with_deleted => true
 
   belongs_to :paranoid_belongs_dependant, :dependent => :destroy
 end


### PR DESCRIPTION
This option allows depending objects to access the dependent after it is soft-deleted.  This was present in acts_as_paranoid and is useful for us.

Can you add this for the next release?
