### PR TITLE
improve rails 3.1.x compatible code

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -32,7 +32,7 @@ module ActsAsParanoid
     end
     
     ActiveRecord::Reflection::AssociationReflection.class_eval do
-      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
+      alias_method :foreign_key, :primary_key_name unless instance_methods.include?(:foreign_key)
     end
 
     # Magic!

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -4,27 +4,24 @@ module ParanoidValidations
   class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
     def validate_each(record, attribute, value)
       finder_class = find_finder_class_for(record)
+      table = finder_class.arel_table
 
-      if value && record.class.serialized_attributes.key?(attribute.to_s)
-        value = YAML.dump value
+      coder = record.class.serialized_attributes[attribute.to_s]
+
+      if value && coder
+        value = coder.dump value
       end
 
-      sql, params = mount_sql_and_params(finder_class, record.class.quoted_table_name, attribute, value)
+      relation = build_relation(finder_class, table, attribute, value)
+      relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
 
-      # This is the only changed line from the base class version - it does finder_class.unscoped
-      relation = finder_class.where(sql, *params)
-      
       Array.wrap(options[:scope]).each do |scope_item|
         scope_value = record.send(scope_item)
-        relation = relation.where(scope_item => scope_value)
+        relation = relation.and(table[scope_item].eq(scope_value))
       end
 
-      if record.persisted?
-        # TODO : This should be in Arel
-        relation = relation.where("#{record.class.quoted_table_name}.#{record.class.primary_key} <> ?", record.send(:id))
-      end
-
-      if relation.exists?
+      # This is the only changed line from the base class version - it does finder_class.unscoped
+      if finder_class.where(relation).exists?
         record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
       end
     end


### PR DESCRIPTION
- avoid warnings below
  - DEPRECATION WARNING: primary_key_name is deprecated and will be removed from Rails 3.2 (use foreign_key instead).
  - NoMethodError: undefined method `mount_sql_and_params' for #ParanoidValidations::UniquenessWithoutDeletedValidator:0x00000002e99010
