### PR TITLE
rails3_acts_as_paranoid regression tests, relations, and bug fixes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem "rails3_acts_as_paranoid", :path => File.expand_path("..", __FILE__)
 
 # Development dependencies 
 gem "rake"
-gem "activesupport", "~>3.0"
+gem "activesupport", "~>3.1"
 gem "sqlite3-ruby"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails3_acts_as_paranoid", :path => File.expand_path("..", __FILE__)
+gem "activerecord", "~>3.1"
 
 # Development dependencies 
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails3_acts_as_paranoid (0.1.1)
+    rails3_acts_as_paranoid (0.1.1.1)
       activerecord (~> 3.0)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     sqlite3 (1.3.3)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
-    tzinfo (0.3.29)
+    tzinfo (0.3.31)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,38 @@
 PATH
   remote: .
   specs:
-    rails3_acts_as_paranoid (0.1.1)
-      activerecord (~> 3.0)
+    rails3_acts_as_paranoid (0.1.1.2)
+      activerecord (~> 3.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.9)
-      activesupport (= 3.0.9)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activerecord (3.0.9)
-      activemodel (= 3.0.9)
-      activesupport (= 3.0.9)
-      arel (~> 2.0.10)
-      tzinfo (~> 0.3.23)
-    activesupport (3.0.9)
-    arel (2.0.10)
-    builder (2.1.2)
-    i18n (0.5.0)
-    rake (0.8.7)
-    sqlite3 (1.3.3)
+    activemodel (3.1.3)
+      activesupport (= 3.1.3)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activerecord (3.1.3)
+      activemodel (= 3.1.3)
+      activesupport (= 3.1.3)
+      arel (~> 2.2.1)
+      tzinfo (~> 0.3.29)
+    activesupport (3.1.3)
+      multi_json (~> 1.0)
+    arel (2.2.1)
+    builder (3.0.0)
+    i18n (0.6.0)
+    multi_json (1.0.4)
+    rake (0.9.2.2)
+    sqlite3 (1.3.5)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
-    tzinfo (0.3.29)
+    tzinfo (0.3.31)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (~> 3.1)
   rails3_acts_as_paranoid!
   rake
   sqlite3-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-PATH
-  remote: .
-  specs:
-    rails3_acts_as_paranoid (0.1.1.2)
-      activerecord (~> 3.1)
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -32,7 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord (~> 3.1)
   activesupport (~> 3.1)
-  rails3_acts_as_paranoid!
   rake
   sqlite3-ruby

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -72,6 +72,18 @@ module ActsAsParanoid
     def only_deleted
       self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
     end
+    
+    def deletion_conditions(id_or_array)
+      ["id in (?)", [id_or_array].flatten]
+    end
+    
+    def delete!(id_or_array)
+      delete_all!(deletion_conditions(id_or_array))
+    end
+    
+    def delete(id_or_array)
+      delete_all(deletion_conditions(id_or_array))
+    end
 
     def delete_all!(conditions = nil)
       self.unscoped.delete_all!(conditions)

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -15,15 +15,7 @@ module ActiveRecord
     alias_method :destroy!, :destroy
     def destroy(id)
       if paranoid?
-        attributes = paranoid_deletion_attributes
-        if id.is_a?(Array)
-          # For some reason, if you pass an array of IDs, ActiveRecord expects
-          # an array of attributes too; you can expect the same attributes to be 
-          # applied to all of the updated records.
-          # To compensate, pass an array of the same attributes instead
-          attributes = id.map {|i| attributes}
-        end
-        update(id, attributes)
+        update_all(paranoid_deletion_attributes, {:id => id})
       else
         destroy!(id)
       end

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -133,6 +133,27 @@ module ActsAsParanoid
       end
     end
     
+    def delete!
+      with_transaction_returning_status do
+        act_on_dependent_destroy_associations
+        self.class.delete_all!(self.class.primary_key.to_sym => self.id)
+        self.paranoid_value = self.class.delete_now_value
+        freeze
+      end
+    end
+    
+    def delete
+      if paranoid_value.nil?
+        with_transaction_returning_status do
+          self.class.delete_all(self.class.primary_key.to_sym => self.id)
+          self.paranoid_value = self.class.delete_now_value
+          self
+        end
+      else
+        delete!
+      end
+    end
+    
     def recover(options={})
       options = {
                   :recursive => self.class.paranoid_configuration[:recover_dependent_associations],

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -31,10 +31,6 @@ module ActsAsParanoid
       alias_method :destroy!, :destroy
     end
     
-    ActiveRecord::Reflection::AssociationReflection.class_eval do
-      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
-    end
-
     # Magic!
     default_scope where("#{paranoid_column_reference} IS ?", nil)
     

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -15,7 +15,15 @@ module ActiveRecord
     alias_method :destroy!, :destroy
     def destroy(id)
       if paranoid?
-        update(id, paranoid_deletion_attributes)
+        attributes = paranoid_deletion_attributes
+        if id.is_a?(Array)
+          # For some reason, if you pass an array of IDs, ActiveRecord expects
+          # an array of attributes too; you can expect the same attributes to be 
+          # applied to all of the updated records.
+          # To compensate, pass an array of the same attributes instead
+          attributes = id.map {|i| attributes}
+        end
+        update(id, attributes)
       else
         destroy!(id)
       end

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -39,6 +39,17 @@ module ActiveRecord
         delete_all!(conditions)
       end
     end
+    
+    def arel=(a)
+      @arel = a
+    end
+    
+    def with_deleted
+      wd = self.clone
+      wd.default_scoped = false
+      wd.arel = self.build_arel
+      wd
+    end
   end
 end
 

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -25,6 +25,7 @@ module ActiveRecord
     
     def delete_all!(conditions = nil)
       if conditions
+        # This idea comes out of Rails 3.1 ActiveRecord::Record.delete_all
         where(conditions).delete_all!
       else
         really_delete_all!

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -9,7 +9,8 @@ module ParanoidValidations
         value = YAML.dump value
       end
 
-      sql, params = build_relation(finder_class, record.class.quoted_table_name, attribute, value)
+      table = Arel::Table.new(record.class.table_name)
+      sql, params = build_relation(finder_class, table, attribute, value)
 
       # This is the only changed line from the base class version - it does finder_class.unscoped
       relation = finder_class.where(sql, *params)

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -9,7 +9,7 @@ module ParanoidValidations
         value = YAML.dump value
       end
 
-      sql, params = mount_sql_and_params(finder_class, record.class.quoted_table_name, attribute, value)
+      sql, params = build_relation(finder_class, record.class.quoted_table_name, attribute, value)
 
       # This is the only changed line from the base class version - it does finder_class.unscoped
       relation = finder_class.where(sql, *params)

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -5,13 +5,13 @@ Gem::Specification.new do |s|
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]
   s.homepage          = "https://github.com/softcraft-development/rails3_acts_as_paranoid"
-  s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
-  s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
+  s.summary           = "Active Record (>=3.1) plugin which allows you to hide and restore records without actually deleting them."
+  s.description       = "Active Record (>=3.1) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name
 
   s.required_rubygems_version = ">= 1.3.6"
   
-  s.add_dependency "activerecord", "~> 3.0"
+  s.add_dependency "activerecord", "~> 3.1"
 
   s.files        = Dir["{lib}/**/*.rb", "LICENSE", "*.markdown"]
 end

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1.3"
+  s.version           = "0.1.1.4"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1.1"
+  s.version           = "0.1.1.2"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1.2"
+  s.version           = "0.1.1.3"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Goncalo Silva", "Craig Walker"]
   s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.1.1"
+  s.version           = "0.1.1.1"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Goncalo Silva"]
-  s.email             = ["goncalossilva@gmail.com"]
-  s.homepage          = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
+  s.authors           = ["Goncalo Silva", "Craig Walker"]
+  s.email             = ["goncalossilva@gmail.com", "craig@softcraft.ca"]
+  s.homepage          = "https://github.com/softcraft-development/rails3_acts_as_paranoid"
   s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
   s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -13,7 +13,7 @@ class MoreParanoidTest < ParanoidBaseTest
     left.reload
     
     assert_equal [], left.paranoid_many_many_children
-    # assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
+    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
     assert_equal right, ParanoidManyManyParentRight.find(right.id)
   end
   

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -30,11 +30,7 @@ class MoreParanoidTest < ParanoidBaseTest
     
     assert_equal [], left.paranoid_many_many_children, "Child records still exist"
     assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
-    
-    # Destroying the associated really destroys it; it's not just removed from the collection
-    assert_raises ActiveRecord::RecordNotFound do
-      ParanoidManyManyParentRight.find(right.id)
-    end
+    assert_equal right, ParanoidManyManyParentRight.find(right.id)
   end
   
   test "cannot find a has_many :through object when its linking object is paranoid destroyed" do

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,4 +1,4 @@
-require "#{File.dirname(__FILE__)}/test_helper"
+require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
   test "instance destroy is paranoid" do

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "destroy by multiple id is paranoid" do
+    model_a = ParanoidBelongsDependant.create
+    model_b = ParanoidBelongsDependant.create
+    ParanoidBelongsDependant.destroy([model_a.id, model_b.id])
+    
+    assert_paranoid_deletion(model_a)
+    assert_paranoid_deletion(model_b)
+  end
+  
   test "delete by single id is paranoid" do
     model = ParanoidBelongsDependant.create
     ParanoidBelongsDependant.delete(model.id)

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -2,6 +2,20 @@ require 'test_helper'
 
 
 class MoreParanoidTest < ParanoidBaseTest
+    test "bidirectional has_many :through association clear is paranoid" do
+    left = ParanoidManyManyParentLeft.create
+    right = ParanoidManyManyParentRight.create
+    left.paranoid_many_many_parent_rights << right
+    
+    child = left.paranoid_many_many_children.first
+    assert_equal left, child.paranoid_many_many_parent_left, "Child's left parent is incorrect"
+    assert_equal right, child.paranoid_many_many_parent_right, "Child's right parent is incorrect"
+    
+    left.paranoid_many_many_parent_rights.clear
+    
+    assert_paranoid_deletion(child)
+  end
+  
   test "bidirectional has_many :through association delete is paranoid" do
     left = ParanoidManyManyParentLeft.create
     right = ParanoidManyManyParentRight.create

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,23 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "only find associated records when finding with paranoid deleted" do
+    parent = ParanoidBelongsDependant.create
+    child = ParanoidHasManyDependant.create
+    parent.paranoid_has_many_dependants << child
+    
+    unrelated_parent = ParanoidBelongsDependant.create
+    unrelated_child = ParanoidHasManyDependant.create
+    unrelated_parent.paranoid_has_many_dependants << unrelated_child
+    
+    child.destroy
+    assert_paranoid_deletion(child)
+    
+    parent.reload
+    
+    assert_equal [child], parent.paranoid_has_many_dependants.with_deleted.to_a
+  end
+  
   test "models with scoped validations can be multiply deleted" do
     model_a = ParanoidWithScopedValidation.create(:name => "Model A", :category => "Category A")
     model_b = ParanoidWithScopedValidation.create(:name => "Model B", :category => "Category B")

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -12,9 +12,9 @@ class MoreParanoidTest < ParanoidBaseTest
 
     left.reload
     
-    assert_equal [], left.paranoid_many_many_children
-    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
-    assert_equal right, ParanoidManyManyParentRight.find(right.id)
+    assert_equal [], left.paranoid_many_many_children, "Linking objects not deleted"
+    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not unlinked"
+    assert_equal right, ParanoidManyManyParentRight.find(right.id), "Associated object deleted"
   end
   
   test "cannot find a paranoid destroyed many:many association" do
@@ -28,9 +28,9 @@ class MoreParanoidTest < ParanoidBaseTest
     
     left.reload
     
-    assert_equal [], left.paranoid_many_many_children, "Child records still exist"
-    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
-    assert_equal right, ParanoidManyManyParentRight.find(right.id)
+    assert_equal [], left.paranoid_many_many_children, "Linking objects not deleted"
+    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not unlinked"
+    assert_equal right, ParanoidManyManyParentRight.find(right.id), "Associated object deleted"
   end
   
   test "cannot find a has_many :through object when its linking object is paranoid destroyed" do

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,26 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "models with scoped validations can be multiply deleted" do
+    model_a = ParanoidWithScopedValidation.create(:name => "Model A", :category => "Category A")
+    model_b = ParanoidWithScopedValidation.create(:name => "Model B", :category => "Category B")
+    
+    ParanoidWithScopedValidation.delete([model_a.id, model_b.id])
+    
+    assert_paranoid_deletion(model_a)
+    assert_paranoid_deletion(model_b)
+  end
+  
+  test "models with scoped validations can be multiply destroyed" do
+    model_a = ParanoidWithScopedValidation.create(:name => "Model A", :category => "Category A")
+    model_b = ParanoidWithScopedValidation.create(:name => "Model B", :category => "Category B")
+    
+    ParanoidWithScopedValidation.destroy([model_a.id, model_b.id])
+    
+    assert_paranoid_deletion(model_a)
+    assert_paranoid_deletion(model_b)
+  end
+
   test "cannot find a paranoid deleted many:many association" do
     left = ParanoidManyManyParentLeft.create
     right = ParanoidManyManyParentRight.create

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "delete by multiple id is paranoid" do
+    model_a = ParanoidBelongsDependant.create
+    model_b = ParanoidBelongsDependant.create
+    ParanoidBelongsDependant.delete([model_a.id, model_b.id])
+    
+    assert_paranoid_deletion(model_a)
+    assert_paranoid_deletion(model_b)
+  end
+  
   test "destroy by multiple id is paranoid" do
     model_a = ParanoidBelongsDependant.create
     model_b = ParanoidBelongsDependant.create

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "destroy by single id is paranoid" do
+    model = ParanoidBelongsDependant.create
+    ParanoidBelongsDependant.destroy(model.id)
+    
+    assert_paranoid_deletion(model)
+  end
+  
   test "instance delete is paranoid" do
     model = ParanoidBelongsDependant.create
     model.delete

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,0 +1,27 @@
+require "#{File.dirname(__FILE__)}/test_helper"
+
+class MoreParanoidTest < ParanoidBaseTest
+  test "instance destroy is paranoid" do
+    model = ParanoidBelongsDependant.create
+    model.destroy
+    
+    assert_paranoid_deletion(model)
+  end
+
+  def find_row(model)
+    sql = "select deleted_at from #{model.class.table_name} where id = #{model.id}"
+    # puts sql here if you want to debug
+    model.class.connection.select_one(sql)
+  end
+  
+  def assert_paranoid_deletion(model)
+    row = find_row(model)
+    assert_not_nil row, "#{model.class} entirely deleted"
+    assert_not_nil row["deleted_at"], "Deleted at not set"
+  end
+  
+  def assert_non_paranoid_deletion(model)
+    row = find_row(model)
+    assert_nil row, "#{model.class} still exists"
+  end
+end

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "instance delete is paranoid" do
+    model = ParanoidBelongsDependant.create
+    model.delete
+    
+    assert_paranoid_deletion(model)
+  end
+  
   test "instance destroy is paranoid" do
     model = ParanoidBelongsDependant.create
     model.destroy

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -2,7 +2,16 @@ require 'test_helper'
 
 
 class MoreParanoidTest < ParanoidBaseTest
-    test "bidirectional has_many :through association clear is paranoid" do
+  test "cannot find a paranoid deleted model" do
+    model = ParanoidBelongsDependant.create
+    model.destroy
+    
+    assert_raises ActiveRecord::RecordNotFound do
+      ParanoidBelongsDependant.find(model.id)
+    end
+  end
+  
+  test "bidirectional has_many :through association clear is paranoid" do
     left = ParanoidManyManyParentLeft.create
     right = ParanoidManyManyParentRight.create
     left.paranoid_many_many_parent_rights << right

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class MoreParanoidTest < ParanoidBaseTest
+  test "delete by single id is paranoid" do
+    model = ParanoidBelongsDependant.create
+    ParanoidBelongsDependant.delete(model.id)
+    
+    assert_paranoid_deletion(model)
+  end
+  
   test "destroy by single id is paranoid" do
     model = ParanoidBelongsDependant.create
     ParanoidBelongsDependant.destroy(model.id)

--- a/test/more_paranoid_test.rb
+++ b/test/more_paranoid_test.rb
@@ -1,6 +1,21 @@
 require 'test_helper'
 
+
 class MoreParanoidTest < ParanoidBaseTest
+  test "bidirectional has_many :through association delete is paranoid" do
+    left = ParanoidManyManyParentLeft.create
+    right = ParanoidManyManyParentRight.create
+    left.paranoid_many_many_parent_rights << right
+    
+    child = left.paranoid_many_many_children.first
+    assert_equal left, child.paranoid_many_many_parent_left, "Child's left parent is incorrect"
+    assert_equal right, child.paranoid_many_many_parent_right, "Child's right parent is incorrect"
+    
+    left.paranoid_many_many_parent_rights.delete(right)
+    
+    assert_paranoid_deletion(child)
+  end
+  
   test "delete by multiple id is paranoid" do
     model_a = ParanoidBelongsDependant.create
     model_b = ParanoidBelongsDependant.create

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -1,30 +1,5 @@
 require 'test_helper'
 
-class ParanoidBaseTest < ActiveSupport::TestCase
-  def assert_empty(collection)
-    assert(collection.respond_to?(:empty?) && collection.empty?)
-  end
-  
-  def setup
-    setup_db
-
-    ["paranoid", "really paranoid", "extremely paranoid"].each do |name|
-      ParanoidTime.create! :name => name
-      ParanoidBoolean.create! :name => name
-    end
-
-    ParanoidString.create! :name => "strings can be paranoid"
-    NotParanoid.create! :name => "no paranoid goals"
-    ParanoidWithCallback.create! :name => "paranoid with callbacks"
-
-    ParanoidObserver.instance.reset
-  end
-
-  def teardown
-    teardown_db
-  end
-end
-
 class ParanoidTest < ParanoidBaseTest
   def test_fake_removal
     assert_equal 3, ParanoidTime.count

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,6 +118,24 @@ def setup_db
       
       t.timestamps
     end
+    
+    create_table :paranoid_many_many_parent_lefts do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table :paranoid_many_many_parent_rights do |t|
+      t.string :name
+      t.timestamps
+    end
+    
+    create_table :paranoid_many_many_children do |t|
+      t.integer :paranoid_many_many_parent_left_id
+      t.integer :paranoid_many_many_parent_right_id
+      t.datetime :deleted_at
+      t.timestamps
+    end
+    
   end
 end
 
@@ -268,6 +286,24 @@ class ParanoidObserver < ActiveRecord::Observer
     self.called_after_recover = nil
   end
 end
+
+
+class ParanoidManyManyParentLeft < ActiveRecord::Base
+  has_many :paranoid_many_many_children
+  has_many :paranoid_many_many_parent_rights, :through => :paranoid_many_many_children
+end
+
+class ParanoidManyManyParentRight < ActiveRecord::Base
+  has_many :paranoid_many_many_children
+  has_many :paranoid_many_many_parent_lefts, :through => :paranoid_many_many_children
+end
+
+class ParanoidManyManyChild < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_many_many_parent_left
+  belongs_to :paranoid_many_many_parent_right
+end
+
 
 ParanoidWithCallback.add_observer(ParanoidObserver.instance)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -270,3 +270,29 @@ class ParanoidObserver < ActiveRecord::Observer
 end
 
 ParanoidWithCallback.add_observer(ParanoidObserver.instance)
+
+
+class ParanoidBaseTest < ActiveSupport::TestCase
+  def assert_empty(collection)
+    assert(collection.respond_to?(:empty?) && collection.empty?)
+  end
+  
+  def setup
+    setup_db
+
+    ["paranoid", "really paranoid", "extremely paranoid"].each do |name|
+      ParanoidTime.create! :name => name
+      ParanoidBoolean.create! :name => name
+    end
+
+    ParanoidString.create! :name => "strings can be paranoid"
+    NotParanoid.create! :name => "no paranoid goals"
+    ParanoidWithCallback.create! :name => "paranoid with callbacks"
+
+    ParanoidObserver.instance.reset
+  end
+
+  def teardown
+    teardown_db
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,6 +136,13 @@ def setup_db
       t.timestamps
     end
     
+    create_table :paranoid_with_scoped_validations do |t|
+      t.string :name
+      t.string :category
+      t.datetime :deleted_at
+      t.timestamps
+    end
+    
   end
 end
 
@@ -302,6 +309,11 @@ class ParanoidManyManyChild < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_many_many_parent_left
   belongs_to :paranoid_many_many_parent_right
+end
+
+class ParanoidWithScopedValidation < ActiveRecord::Base
+  acts_as_paranoid
+  validates_uniqueness_of :name, :scope => :category
 end
 
 


### PR DESCRIPTION
Hello again. Sorry for the delay, but I've finally gotten a chance to catch up on my backlog of work.

I am working on a project to upgrade our app from Rails 2.3.10 to 3.1. As a part of that, we chose your gem to replace the old `acts_as_paranoid` gem. (And thank you very much for taking on that project BTW.)

During the upgrade, we noticed that some of our tests were breaking. We traced this to differences in the behaviour from `acts_as_paranoid` (which we had built tests around) to `rails3_acts_as_paranoid`. As you might expect, the differences were largely in edge cases, not implemented in your gem or covered by your test cases. 

Since we had a lot of application functionality built around that behaviour, we decided to fork the gem and add in the functionality we needed. We built a set of tests (originally in the Rails 2/`acts_as_paranoid` version of our app) specifically designed to verify that behaviour, then added code into our own `rails3_acts_as_paranoid` for until they passed. (Those tests, when scrubbed of business context, became [more_paranoid_test.rb](https://github.com/softcraft-development/rails3_acts_as_paranoid/blob/8f4202625bda7d0ed63b0046344eb6ed82ce7d19/test/more_paranoid_test.rb).

I'll leave it up to you whether you pull these changes into your repository. The functionality we added isn't absolutely necessary, depending on the vision you have for the gem going forward. We just needed it to avoid breaking our app. However, we did add some nifty features, so it may be worthwhile to pull it into the main codebase.

Here's what we did:
- Updated the requirements to [Rails 3.1](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/d285a89155fcb5f2e3eb57f7359dc3f80923ee12). 
  *\* As I mentioned earlier, the underlying ActiveRecord code changed drastically between Rails 3.0 and 3.1.
  *\* I haven't even begun to research whether we'll need another round of changes for Rails 3.2
- Added the ability to [find all deleted records through a Relation](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/744ebb61414284f816a05f53a18c7e2805773bf1) (association)
  *\* In the original code, calling `with_deleted` dropped _all_ scopes from the association, including the one that joined the two tables together.
- Fixed an issue that caused [violations of validate_uniquess_of](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/ca857ee2f9a519e3b00f10184fae136b5116f032) during paranoid deletions.
- Added the ability to [paranoid delete/destroy all records through a relation](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/f09e90e2a8599b71fc09d24373fd98591e254535).
- [Removed the deprecated aliasing of `primary_key_name'](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/819f99a6e6a904510eb132a40a61be1b076bc02f).
- [Fixed](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/5b57d70e0e9faae03fd8e0e2e3d5ef67fd2cf0de) [errors](https://github.com/softcraft-development/rails3_acts_as_paranoid/commit/040c0c8829b39387765af75352d276ae1c10dc61) in `uniqueness_without_deleted` relating to new Rails 3 code.
- Expanded the test coverage, particularly in cases of paranoid deleted associated records.

So far, it's been working really well for us. If you have any questions, just let me know.

Thanks,

Craig
