### PR TITLE
undefined method 'primary_key_name' in rails 3.2.1

### DIFF
--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -32,7 +32,7 @@ module ActsAsParanoid
     end
     
     ActiveRecord::Reflection::AssociationReflection.class_eval do
-      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
+      alias_method :foreign_key, :primary_key_name if respond_to?(:primary_key_name) && !respond_to?(:foreign_key)
     end
 
     # Magic!


### PR DESCRIPTION
In rails 3.2.1 I was getting

```
undefined method 'primary_key_name' in rails 3.2.1
```

I guess foreign_key got moved elsewhere. This simple change (checking if method that we want to alias is defined) seems to be fixing the issue.
