### PR TITLE
Rails 3.2, default scope support, chainable scopes/associations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem "rails3_acts_as_paranoid", :path => File.expand_path("..", __FILE__)
 
 # Development dependencies 
 gem "rake"
-gem "activesupport", "~>3.0"
+gem "activesupport", "~>3.2"
 gem "sqlite3-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,35 +2,37 @@ PATH
   remote: .
   specs:
     rails3_acts_as_paranoid (0.1.1)
-      activerecord (~> 3.0)
+      activerecord (~> 3.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.9)
-      activesupport (= 3.0.9)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activerecord (3.0.9)
-      activemodel (= 3.0.9)
-      activesupport (= 3.0.9)
-      arel (~> 2.0.10)
-      tzinfo (~> 0.3.23)
-    activesupport (3.0.9)
-    arel (2.0.10)
-    builder (2.1.2)
-    i18n (0.5.0)
-    rake (0.8.7)
-    sqlite3 (1.3.3)
+    activemodel (3.2.0)
+      activesupport (= 3.2.0)
+      builder (~> 3.0.0)
+    activerecord (3.2.0)
+      activemodel (= 3.2.0)
+      activesupport (= 3.2.0)
+      arel (~> 3.0.0)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.0)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    arel (3.0.0)
+    builder (3.0.0)
+    i18n (0.6.0)
+    multi_json (1.0.4)
+    rake (0.9.2.2)
+    sqlite3 (1.3.5)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
-    tzinfo (0.3.29)
+    tzinfo (0.3.31)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (~> 3.2)
   rails3_acts_as_paranoid!
   rake
   sqlite3-ruby

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -17,8 +17,8 @@ module ActsAsParanoid
         if with_deleted
           class_eval <<-RUBY, __FILE__, __LINE__
             def #{target}_with_unscoped(*args)
-              return #{target}_without_unscoped(*args) unless #{result.klass}.paranoid?
-              #{result.klass}.unscoped { #{target}_without_unscoped(*args) }
+              return #{target}_without_unscoped(*args) unless association(:#{target}).klass.paranoid?
+              association(:#{target}).klass.with_deleted.merge(association(:#{target}).association_scope)
             end
             alias_method_chain :#{target}, :unscoped
           RUBY

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -1,0 +1,31 @@
+module ActsAsParanoid
+  module Associations
+    def self.included(base)
+      base.extend ClassMethods
+      base.class_eval do
+        class << self
+          alias_method_chain :belongs_to, :deleted
+        end
+      end
+    end
+
+    module ClassMethods
+      def belongs_to_with_deleted(target, options = {})
+        with_deleted = options.delete(:with_deleted)
+        result = belongs_to_without_deleted(target, options)
+      
+        if with_deleted
+          class_eval <<-RUBY, __FILE__, __LINE__
+            def #{target}_with_unscoped(*args)
+              return #{target}_without_unscoped(*args) unless #{result.klass}.paranoid?
+              #{result.klass}.unscoped { #{target}_without_unscoped(*args) }
+            end
+            alias_method_chain :#{target}, :unscoped
+          RUBY
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -18,7 +18,7 @@ module ActsAsParanoid
           class_eval <<-RUBY, __FILE__, __LINE__
             def #{target}_with_unscoped(*args)
               return #{target}_without_unscoped(*args) unless association(:#{target}).klass.paranoid?
-              association(:#{target}).klass.with_deleted.merge(association(:#{target}).association_scope)
+              association(:#{target}).klass.with_deleted.scoping { #{target}_without_unscoped(*args) }
             end
             alias_method_chain :#{target}, :unscoped
           RUBY

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -1,0 +1,159 @@
+module ActsAsParanoid
+  module Core
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def self.extended(base)
+        base.define_callbacks :recover
+      end
+
+      def before_recover(method)
+        set_callback :recover, :before, method
+      end
+
+      def after_recover(method)
+        set_callback :recover, :after, method
+      end
+
+      def with_deleted
+        without_paranoid_default_scope
+      end
+
+      def only_deleted
+        without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
+      end
+
+      def delete_all!(conditions = nil)
+        without_paranoid_default_scope.delete_all!(conditions)
+      end
+
+      def delete_all(conditions = nil)
+        update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
+      end
+
+      def paranoid_default_scope_sql
+        self.scoped.table[paranoid_column].eq(nil).to_sql
+      end
+
+      def paranoid_column
+        paranoid_configuration[:column].to_sym
+      end
+
+      def paranoid_column_type
+        paranoid_configuration[:column_type].to_sym
+      end
+
+      def dependent_associations
+        self.reflect_on_all_associations.select {|a| [:destroy, :delete_all].include?(a.options[:dependent]) }
+      end
+
+      def delete_now_value
+        case paranoid_configuration[:column_type]
+        when "time" then Time.now
+        when "boolean" then true
+        when "string" then paranoid_configuration[:deleted_value]
+        end
+      end
+
+    protected 
+
+      def without_paranoid_default_scope
+        scope = self.scoped.with_default_scope
+        scope.where_values.delete(paranoid_default_scope_sql)
+
+        scope
+      end
+    end
+
+    def paranoid_value
+      self.send(self.class.paranoid_column)
+    end
+
+    def destroy!
+      with_transaction_returning_status do
+        run_callbacks :destroy do
+          act_on_dependent_destroy_associations
+          self.class.delete_all!(self.class.primary_key.to_sym => self.id)
+          self.paranoid_value = self.class.delete_now_value
+          freeze
+        end
+      end
+    end
+
+    def destroy
+      if paranoid_value.nil?
+        with_transaction_returning_status do
+          run_callbacks :destroy do
+            self.class.delete_all(self.class.primary_key.to_sym => self.id)
+            self.paranoid_value = self.class.delete_now_value
+            self
+          end
+        end
+      else
+        destroy!
+      end
+    end
+
+    def recover(options={})
+      options = {
+        :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
+        :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
+      }.merge(options)
+
+      self.class.transaction do
+        run_callbacks :recover do
+          recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
+
+          self.paranoid_value = nil
+          self.save
+        end
+      end
+    end
+
+    def recover_dependent_associations(window, options)
+      self.class.dependent_associations.each do |association|
+        if association.collection? && self.send(association.name).paranoid?
+          self.send(association.name).unscoped do
+            self.send(association.name).paranoid_deleted_around_time(paranoid_value, window).each do |object|
+              object.recover(options) if object.respond_to?(:recover)
+            end
+          end
+        elsif association.macro == :has_one && association.klass.paranoid?
+          association.klass.unscoped do
+            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).send('find_by_'+association.foreign_key, self.id)
+            object.recover(options) if object && object.respond_to?(:recover)
+          end
+        elsif association.klass.paranoid?
+          association.klass.unscoped do
+            id = self.send(association.foreign_key)
+            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).find_by_id(id)
+            object.recover(options) if object && object.respond_to?(:recover)
+          end
+        end
+      end
+    end
+
+    def act_on_dependent_destroy_associations
+      self.class.dependent_associations.each do |association|
+        if association.collection? && self.send(association.name).paranoid?
+          association.klass.with_deleted.instance_eval("find_all_by_#{association.foreign_key}(#{self.id.to_json})").each do |object|
+            object.destroy!
+          end
+        end
+      end
+    end
+
+    def deleted?
+      !paranoid_value.nil?
+    end
+    alias_method :destroyed?, :deleted?
+
+    private
+
+    def paranoid_value=(value)
+      self.send("#{self.class.paranoid_column}=", value)
+    end
+  end
+end

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -1,7 +1,12 @@
 require 'active_support/core_ext/array/wrap'
 
-module ParanoidValidations
-  class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
+module ActsAsParanoid
+  module Validations
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
       def validate_each(record, attribute, value)
         finder_class = find_finder_class_for(record)
         table = finder_class.arel_table
@@ -26,11 +31,12 @@ module ParanoidValidations
           record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
         end
       end
-  end
+    end
 
-  module ClassMethods
-    def validates_uniqueness_of_without_deleted(*attr_names)
-      validates_with UniquenessWithoutDeletedValidator, _merge_attributes(attr_names)
+    module ClassMethods
+      def validates_uniqueness_of_without_deleted(*attr_names)
+        validates_with UniquenessWithoutDeletedValidator, _merge_attributes(attr_names)
+      end
     end
   end
 end

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -25,9 +25,8 @@ module ActsAsParanoid
           relation = relation.and(table[scope_item].eq(scope_value))
         end
 
-        # Removed unscoped:
-        # finder_class.unscoped.where(relation).exists?
-        if finder_class.where(relation).exists?
+        # Re-add ActsAsParanoid default scope conditions manually. 
+        if finder_class.unscoped.where(finder_class.paranoid_default_scope_sql).where(relation).exists?
           record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
         end
       end

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -30,10 +30,6 @@ module ActsAsParanoid
       alias_method :delete_all!, :delete_all
       alias_method :destroy!, :destroy
     end
-    
-    ActiveRecord::Reflection::AssociationReflection.class_eval do
-      alias_method :foreign_key, :primary_key_name unless respond_to?(:foreign_key)
-    end
 
     # Magic!
     default_scope where("#{paranoid_column_reference} IS ?", nil)

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'validations/uniqueness_without_deleted'
+require 'acts_as_paranoid/associations'
 
 module ActsAsParanoid
   
@@ -46,6 +47,7 @@ module ActsAsParanoid
     
     include InstanceMethods
     extend ClassMethods
+    include ActsAsParanoid::Associations
   end
 
   module ClassMethods

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -28,7 +28,7 @@ module ActsAsParanoid
 
     ActiveRecord::Relation.class_eval do
       alias_method :delete_all!, :delete_all
-      alias_method :destroy!, :destroy
+      alias_method :destroy!, :delete
     end
 
     # Magic!

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -70,7 +70,7 @@ module ActsAsParanoid
     end
 
     def delete_all!(conditions = nil)
-      self.unscoped.delete_all!(conditions)
+      without_paranoid_default_scope.delete_all!(conditions)
     end
 
     def delete_all(conditions = nil)

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -62,11 +62,11 @@ module ActsAsParanoid
     end
 
     def with_deleted
-      self.unscoped
+      disable_default_scope
     end
 
     def only_deleted
-      self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+      disable_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
     end
 
     def delete_all!(conditions = nil)
@@ -95,6 +95,15 @@ module ActsAsParanoid
         when "boolean" then true
         when "string" then paranoid_configuration[:deleted_value]
       end
+    end
+
+    protected 
+
+    def disable_default_scope
+      scope = self.scoped
+      scope.default_scoped = false
+
+      scope
     end
   end
   

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -62,11 +62,11 @@ module ActsAsParanoid
     end
 
     def with_deleted
-      disable_default_scope
+      without_paranoid_default_scope
     end
 
     def only_deleted
-      disable_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
+      without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
     end
 
     def delete_all!(conditions = nil)
@@ -103,10 +103,9 @@ module ActsAsParanoid
 
     protected 
 
-    def disable_default_scope
+    def without_paranoid_default_scope
       scope = self.scoped.with_default_scope
       scope.where_values.delete(paranoid_default_scope_sql)
-      scope.default_scoped = false
 
       scope
     end

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -1,15 +1,16 @@
 require 'active_record'
-require 'validations/uniqueness_without_deleted'
+require 'acts_as_paranoid/core'
 require 'acts_as_paranoid/associations'
+require 'acts_as_paranoid/validations'
 
 module ActsAsParanoid
   
   def paranoid?
-    self.included_modules.include?(InstanceMethods)
+    self.included_modules.include?(ActsAsParanoid::Core)
   end
   
   def validates_as_paranoid
-    extend ParanoidValidations::ClassMethods
+    include ActsAsParanoid::Validations
   end
   
   def acts_as_paranoid(options = {})
@@ -44,167 +45,10 @@ module ActsAsParanoid
         end
       end if paranoid_configuration[:column_type] == 'time'
     }
-    
-    include InstanceMethods
-    extend ClassMethods
+   
+    include ActsAsParanoid::Core
     include ActsAsParanoid::Associations
   end
-
-  module ClassMethods
-    def self.extended(base)
-      base.define_callbacks :recover
-    end
-
-    def before_recover(method)
-      set_callback :recover, :before, method
-    end
-
-    def after_recover(method)
-      set_callback :recover, :after, method
-    end
-
-    def with_deleted
-      without_paranoid_default_scope
-    end
-
-    def only_deleted
-      without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
-    end
-
-    def delete_all!(conditions = nil)
-      without_paranoid_default_scope.delete_all!(conditions)
-    end
-
-    def delete_all(conditions = nil)
-      update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
-    end
-
-    def paranoid_default_scope_sql
-      self.scoped.table[paranoid_column].eq(nil).to_sql
-    end
-
-    def paranoid_column
-      paranoid_configuration[:column].to_sym
-    end
-
-    def paranoid_column_type
-      paranoid_configuration[:column_type].to_sym
-    end
-
-    def dependent_associations
-      self.reflect_on_all_associations.select {|a| [:destroy, :delete_all].include?(a.options[:dependent]) }
-    end
-
-    def delete_now_value
-      case paranoid_configuration[:column_type]
-        when "time" then Time.now
-        when "boolean" then true
-        when "string" then paranoid_configuration[:deleted_value]
-      end
-    end
-
-    protected 
-
-    def without_paranoid_default_scope
-      scope = self.scoped.with_default_scope
-      scope.where_values.delete(paranoid_default_scope_sql)
-
-      scope
-    end
-  end
-  
-  module InstanceMethods
-    
-    def paranoid_value
-      self.send(self.class.paranoid_column)
-    end
-    
-    def destroy!
-      with_transaction_returning_status do
-        run_callbacks :destroy do
-          act_on_dependent_destroy_associations
-          self.class.delete_all!(self.class.primary_key.to_sym => self.id)
-          self.paranoid_value = self.class.delete_now_value
-          freeze
-        end
-      end
-    end
-
-    def destroy
-      if paranoid_value.nil?
-        with_transaction_returning_status do
-          run_callbacks :destroy do
-            self.class.delete_all(self.class.primary_key.to_sym => self.id)
-            self.paranoid_value = self.class.delete_now_value
-            self
-          end
-        end
-      else
-        destroy!
-      end
-    end
-    
-    def recover(options={})
-      options = {
-                  :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
-                  :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
-                }.merge(options)
-
-      self.class.transaction do
-        run_callbacks :recover do
-          recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
-
-          self.paranoid_value = nil
-          self.save
-        end
-      end
-    end
-
-    def recover_dependent_associations(window, options)
-      self.class.dependent_associations.each do |association|
-        if association.collection? && self.send(association.name).paranoid?
-          self.send(association.name).unscoped do
-            self.send(association.name).paranoid_deleted_around_time(paranoid_value, window).each do |object|
-              object.recover(options) if object.respond_to?(:recover)
-            end
-          end
-        elsif association.macro == :has_one && association.klass.paranoid?
-          association.klass.unscoped do
-            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).send('find_by_'+association.foreign_key, self.id)
-            object.recover(options) if object && object.respond_to?(:recover)
-          end
-        elsif association.klass.paranoid?
-          association.klass.unscoped do
-            id = self.send(association.foreign_key)
-            object = association.klass.paranoid_deleted_around_time(paranoid_value, window).find_by_id(id)
-            object.recover(options) if object && object.respond_to?(:recover)
-          end
-        end
-      end
-    end
-    
-    def act_on_dependent_destroy_associations
-      self.class.dependent_associations.each do |association|
-        if association.collection? && self.send(association.name).paranoid?
-          association.klass.with_deleted.instance_eval("find_all_by_#{association.foreign_key}(#{self.id.to_json})").each do |object|
-            object.destroy!
-          end
-        end
-      end
-    end
-
-    def deleted?
-      !paranoid_value.nil?
-    end
-    alias_method :destroyed?, :deleted?
-    
-  private
-    def paranoid_value=(value)
-      self.send("#{self.class.paranoid_column}=", value)
-    end
-    
-  end
-  
 end
 
 # Extend ActiveRecord's functionality

--- a/lib/validations/uniqueness_without_deleted.rb
+++ b/lib/validations/uniqueness_without_deleted.rb
@@ -2,32 +2,30 @@ require 'active_support/core_ext/array/wrap'
 
 module ParanoidValidations
   class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
-    def validate_each(record, attribute, value)
-      finder_class = find_finder_class_for(record)
+      def validate_each(record, attribute, value)
+        finder_class = find_finder_class_for(record)
+        table = finder_class.arel_table
 
-      if value && record.class.serialized_attributes.key?(attribute.to_s)
-        value = YAML.dump value
+        coder = record.class.serialized_attributes[attribute.to_s]
+
+        if value && coder
+          value = coder.dump value
+        end
+
+        relation = build_relation(finder_class, table, attribute, value)
+        relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
+
+        Array.wrap(options[:scope]).each do |scope_item|
+          scope_value = record.send(scope_item)
+          relation = relation.and(table[scope_item].eq(scope_value))
+        end
+
+        # Removed unscoped:
+        # finder_class.unscoped.where(relation).exists?
+        if finder_class.where(relation).exists?
+          record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
+        end
       end
-
-      sql, params = mount_sql_and_params(finder_class, record.class.quoted_table_name, attribute, value)
-
-      # This is the only changed line from the base class version - it does finder_class.unscoped
-      relation = finder_class.where(sql, *params)
-      
-      Array.wrap(options[:scope]).each do |scope_item|
-        scope_value = record.send(scope_item)
-        relation = relation.where(scope_item => scope_value)
-      end
-
-      if record.persisted?
-        # TODO : This should be in Arel
-        relation = relation.where("#{record.class.quoted_table_name}.#{record.class.primary_key} <> ?", record.send(:id))
-      end
-
-      if relation.exists?
-        record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
-      end
-    end
   end
 
   module ClassMethods

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -5,13 +5,13 @@ Gem::Specification.new do |s|
   s.authors           = ["Goncalo Silva"]
   s.email             = ["goncalossilva@gmail.com"]
   s.homepage          = "http://github.com/goncalossilva/rails3_acts_as_paranoid"
-  s.summary           = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them."
-  s.description       = "Active Record (>=3.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
+  s.summary           = "Active Record (>=3.2) plugin which allows you to hide and restore records without actually deleting them."
+  s.description       = "Active Record (>=3.2) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project = s.name
 
   s.required_rubygems_version = ">= 1.3.6"
   
-  s.add_dependency "activerecord", "~> 3.0"
+  s.add_dependency "activerecord", "~> 3.2"
 
   s.files        = Dir["{lib}/**/*.rb", "LICENSE", "*.markdown"]
 end

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -438,26 +438,26 @@ class AssociationsTest < ParanoidBaseTest
     paranoid_time = ParanoidTime.first 
     paranoid_has_many_dependant = paranoid_time.paranoid_has_many_dependants.create(:name => 'dependant!')
 
-    assert paranoid_has_many_dependant.paranoid_time
-    assert paranoid_has_many_dependant.paranoid_time_with_deleted
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time_with_deleted
 
     paranoid_time.destroy
     
     assert_nil paranoid_has_many_dependant.paranoid_time(true)
-    assert paranoid_has_many_dependant.paranoid_time_with_deleted(true)
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time_with_deleted(true)
   end
 
   def test_belongs_to_polymorphic_with_deleted
     paranoid_time = ParanoidTime.first 
     paranoid_has_many_dependant = ParanoidHasManyDependant.create!(:name => 'dependant!', :paranoid_time_polymorphic_with_deleted => paranoid_time)
 
-    assert paranoid_has_many_dependant.paranoid_time
-    assert paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted
 
     paranoid_time.destroy
     
     assert_nil paranoid_has_many_dependant.paranoid_time(true)
-    assert paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted(true)
+    assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted(true)
   end
 end
 

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -26,6 +26,16 @@ class ParanoidBaseTest < ActiveSupport::TestCase
 end
 
 class ParanoidTest < ParanoidBaseTest
+  def test_paranoid?
+    assert !NotParanoid.paranoid?
+    assert_raise(NoMethodError) { NotParanoid.delete_all! }
+    assert_raise(NoMethodError) { NotParanoid.first.destroy! }
+    assert_raise(NoMethodError) { NotParanoid.with_deleted }
+    assert_raise(NoMethodError) { NotParanoid.only_deleted }    
+
+    assert ParanoidTime.paranoid?
+  end
+
   def test_fake_removal
     assert_equal 3, ParanoidTime.count
     assert_equal 3, ParanoidBoolean.count
@@ -66,13 +76,6 @@ class ParanoidTest < ParanoidBaseTest
     ParanoidTime.delete_all!
     assert_empty ParanoidTime.all
     assert_empty ParanoidTime.with_deleted.all
-  end
-
-  def test_paranoid_scope
-    assert_raise(NoMethodError) { NotParanoid.delete_all! }
-    assert_raise(NoMethodError) { NotParanoid.first.destroy! }
-    assert_raise(NoMethodError) { NotParanoid.with_deleted }
-    assert_raise(NoMethodError) { NotParanoid.only_deleted }    
   end
 
   def test_recovery

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -302,35 +302,43 @@ class RelationsTest < ParanoidBaseTest
   def test_fake_removal_through_relation
     # destroy: through a relation.
     ParanoidForest.rainforest.destroy(@paranoid_forest_3)
-    assert 1, ParanoidForest.rainforest
-    assert 2, ParanoidForest.rainforest.with_deleted.count
-    assert 1, ParanoidForest.rainforest.only_deleted.count
+    assert_equal 1, ParanoidForest.rainforest.count
+    assert_equal 2, ParanoidForest.rainforest.with_deleted.count
+    assert_equal 1, ParanoidForest.rainforest.only_deleted.count
 
-    # delete_all: through a relation
-    @paranoid_forest_2.paranoid_trees.order(:id).delete_all
-    assert 0, @paranoid_forest_2.paranoid_trees(true).count
-    assert 2, @paranoid_forest_2.paranoid_trees(true).with_deleted.count
+    # destroy_all: through a relation
+    @paranoid_forest_2.paranoid_trees.order(:id).destroy_all
+    assert_equal 0, @paranoid_forest_2.paranoid_trees(true).count
+    assert_equal 2, @paranoid_forest_2.paranoid_trees(true).with_deleted.count
   end
   
   def test_real_removal_through_relation
-    # destroy!: through a relation.
+    # destroy!: aliased to delete
     ParanoidForest.rainforest.destroy!(@paranoid_forest_3)
-    assert 1, ParanoidForest.rainforest
-    assert 0, ParanoidForest.rainforest.with_deleted.count
-    assert 0, ParanoidForest.rainforest.only_deleted.count
+    assert_equal 1, ParanoidForest.rainforest.count
+    assert_equal 1, ParanoidForest.rainforest.with_deleted.count
+    assert_equal 0, ParanoidForest.rainforest.only_deleted.count
     
     # destroy: two-step through a relation
-    @paranoid_forest_1.paranoid_trees.first.destroy
-    @paranoid_forest_1.paranoid_trees.only_deleted.first.destroy
-    assert 0, @paranoid_forest_1.paranoid_trees(true).count
-    assert 0, @paranoid_forest_1.paranoid_trees(true).with_deleted.count
-    assert 0, @paranoid_forest_1.paranoid_trees(true).only_deleted.count
+    paranoid_tree = @paranoid_forest_1.paranoid_trees.first
+    @paranoid_forest_1.paranoid_trees.order(:id).destroy(paranoid_tree)
+    @paranoid_forest_1.paranoid_trees.only_deleted.destroy(paranoid_tree)
+    assert_equal 1, @paranoid_forest_1.paranoid_trees(true).count
+    assert_equal 1, @paranoid_forest_1.paranoid_trees(true).with_deleted.count
+    assert_equal 0, @paranoid_forest_1.paranoid_trees(true).only_deleted.count
+
+    # destroy_all: two-step through a relation
+    @paranoid_forest_1.paranoid_trees.order(:id).destroy_all
+    @paranoid_forest_1.paranoid_trees.only_deleted.destroy_all
+    assert_equal 0, @paranoid_forest_1.paranoid_trees(true).count
+    assert_equal 0, @paranoid_forest_1.paranoid_trees(true).with_deleted.count
+    assert_equal 0, @paranoid_forest_1.paranoid_trees(true).only_deleted.count
 
     # delete_all!: through a relation
     @paranoid_forest_2.paranoid_trees.order(:id).delete_all!
-    assert 0, @paranoid_forest_2.paranoid_trees(true).count
-    assert 0, @paranoid_forest_2.paranoid_trees(true).with_deleted.count
-    assert 0, @paranoid_forest_2.paranoid_trees(true).only_deleted.count
+    assert_equal 0, @paranoid_forest_2.paranoid_trees(true).count
+    assert_equal 0, @paranoid_forest_2.paranoid_trees(true).with_deleted.count
+    assert_equal 0, @paranoid_forest_2.paranoid_trees(true).only_deleted.count
   end
 end
 

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -230,6 +230,21 @@ class RelationsTest < ParanoidBaseTest
     assert_equal 4, ParanoidTree.count
   end
 
+  def test_double_default_scope
+    # Naturally, the default scope for humans is male. Sexism++
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'female'
+
+    assert_equal 3, ParanoidHuman.count
+
+    ParanoidHuman.first.destroy
+
+    assert_equal 2, ParanoidHuman.count
+    assert_equal 3, ParanoidHuman.with_deleted.count
+  end
+
   def test_filtering_with_scopes
     assert_equal 2, ParanoidForest.rainforest.with_deleted.count
     assert_equal 2, ParanoidForest.with_deleted.rainforest.count

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -430,6 +430,32 @@ class AssociationsTest < ParanoidBaseTest
     assert_equal 0, ParanoidDeleteCompany.with_deleted.count
     assert_equal 0, ParanoidProduct.with_deleted.count
   end
+
+  def test_belongs_to_with_deleted
+    paranoid_time = ParanoidTime.first 
+    paranoid_has_many_dependant = paranoid_time.paranoid_has_many_dependants.create(:name => 'dependant!')
+
+    assert paranoid_has_many_dependant.paranoid_time
+    assert paranoid_has_many_dependant.paranoid_time_with_deleted
+
+    paranoid_time.destroy
+    
+    assert_nil paranoid_has_many_dependant.paranoid_time(true)
+    assert paranoid_has_many_dependant.paranoid_time_with_deleted(true)
+  end
+
+  def test_belongs_to_polymorphic_with_deleted
+    paranoid_time = ParanoidTime.first 
+    paranoid_has_many_dependant = ParanoidHasManyDependant.create!(:name => 'dependant!', :paranoid_time_polymorphic_with_deleted => paranoid_time)
+
+    assert paranoid_has_many_dependant.paranoid_time
+    assert paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted
+
+    paranoid_time.destroy
+    
+    assert_nil paranoid_has_many_dependant.paranoid_time(true)
+    assert paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted(true)
+  end
 end
 
 class InheritanceTest < ParanoidBaseTest

--- a/test/rails3_acts_as_paranoid_test.rb
+++ b/test/rails3_acts_as_paranoid_test.rb
@@ -211,6 +211,57 @@ class ParanoidTest < ParanoidBaseTest
   end
 end
 
+class MultipleDefaultScopesTest < ParanoidBaseTest
+  def setup
+    setup_db
+
+    # Naturally, the default scope for humans is male. Sexism++
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'male'
+    ParanoidHuman.create! :gender => 'female'
+
+    assert_equal 3, ParanoidHuman.count
+    assert_equal 4, ParanoidHuman.unscoped.count
+  end
+
+  def test_fake_removal_with_multiple_default_scope
+    ParanoidHuman.first.destroy
+    assert_equal 2, ParanoidHuman.count
+    assert_equal 3, ParanoidHuman.with_deleted.count
+    assert_equal 1, ParanoidHuman.only_deleted.count
+    assert_equal 4, ParanoidHuman.unscoped.count
+
+    ParanoidHuman.destroy_all
+    assert_equal 0, ParanoidHuman.count
+    assert_equal 3, ParanoidHuman.with_deleted.count
+    assert_equal 3, ParanoidHuman.with_deleted.count
+    assert_equal 4, ParanoidHuman.unscoped.count
+  end
+  
+  def test_real_removal_with_multiple_default_scope
+    # two-step
+    ParanoidHuman.first.destroy
+    ParanoidHuman.only_deleted.first.destroy
+    assert_equal 2, ParanoidHuman.count
+    assert_equal 2, ParanoidHuman.with_deleted.count
+    assert_equal 0, ParanoidHuman.only_deleted.count
+    assert_equal 3, ParanoidHuman.unscoped.count
+
+    ParanoidHuman.first.destroy!
+    assert_equal 1, ParanoidHuman.count
+    assert_equal 1, ParanoidHuman.with_deleted.count
+    assert_equal 0, ParanoidHuman.only_deleted.count
+    assert_equal 2, ParanoidHuman.unscoped.count
+
+    ParanoidHuman.delete_all!
+    assert_equal 0, ParanoidHuman.count
+    assert_equal 0, ParanoidHuman.with_deleted.count
+    assert_equal 0, ParanoidHuman.only_deleted.count
+    assert_equal 1, ParanoidHuman.unscoped.count
+  end
+end
+
 class RelationsTest < ParanoidBaseTest
   def setup
     setup_db 
@@ -228,21 +279,6 @@ class RelationsTest < ParanoidBaseTest
     @paranoid_forest_2.paranoid_trees.create! :name => 'ParanoidTree #4'
 
     assert_equal 4, ParanoidTree.count
-  end
-
-  def test_double_default_scope
-    # Naturally, the default scope for humans is male. Sexism++
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'female'
-
-    assert_equal 3, ParanoidHuman.count
-
-    ParanoidHuman.first.destroy
-
-    assert_equal 2, ParanoidHuman.count
-    assert_equal 3, ParanoidHuman.with_deleted.count
   end
 
   def test_filtering_with_scopes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,6 +134,13 @@ def setup_db
       
       t.timestamps
     end
+
+    create_table :paranoid_humen do |t|
+      t.string   :gender
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
   end
 end
 
@@ -300,4 +307,9 @@ class ParanoidTree < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_forest
   validates_presence_of :name
+end
+
+class ParanoidHuman < ActiveRecord::Base
+  acts_as_paranoid
+  default_scope where('gender IS ?', 'male')
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,6 +118,22 @@ def setup_db
       
       t.timestamps
     end
+
+   create_table :paranoid_forests do |t|
+      t.string   :name
+      t.boolean  :rainforest
+      t.datetime :deleted_at
+      
+      t.timestamps
+    end
+    
+    create_table :paranoid_trees do |t|
+      t.integer  :paranoid_forest_id
+      t.string   :name
+      t.datetime :deleted_at
+      
+      t.timestamps
+    end
   end
 end
 
@@ -129,6 +145,7 @@ end
 
 class ParanoidTime < ActiveRecord::Base
   acts_as_paranoid
+
   validates_uniqueness_of :name
 
   has_many :paranoid_has_many_dependants, :dependent => :destroy
@@ -270,3 +287,17 @@ class ParanoidObserver < ActiveRecord::Observer
 end
 
 ParanoidWithCallback.add_observer(ParanoidObserver.instance)
+
+class ParanoidForest < ActiveRecord::Base
+  acts_as_paranoid
+
+  scope :rainforest, where('rainforest IS ?', true)
+
+  has_many :paranoid_trees, :dependent => :destroy
+end
+
+class ParanoidTree < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_forest
+  validates_presence_of :name
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,7 @@ def setup_db
       t.string    :name
       t.datetime  :deleted_at
       t.integer   :paranoid_time_id
+      t.string    :paranoid_time_polymorphic_with_deleted_type
       t.integer   :paranoid_belongs_dependant_id
 
       t.timestamps
@@ -186,6 +187,8 @@ end
 class ParanoidHasManyDependant < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_time
+  belongs_to :paranoid_time_with_deleted, :class_name => 'ParanoidTime', :foreign_key => :paranoid_time_id, :with_deleted => true
+  belongs_to :paranoid_time_polymorphic_with_deleted, :class_name => 'ParanoidTime', :foreign_key => :paranoid_time_id, :polymorphic => true, :with_deleted => true
 
   belongs_to :paranoid_belongs_dependant, :dependent => :destroy
 end


### PR DESCRIPTION
A collection of updates and enhancements.  I also did a pretty large reorganization of the code (created a `ActsAsParanoid::Core`).
- Updated to support Rails 3.2 (strictly)
- Added support for multiple default scopes on a model 
- Added tests around Klass.paranoid?
- Added tests around deletion through a relation:
  - Fake removal:
    
    ```
      ParanoidObject.scope.destroy(object_id)
      paranoid_object.has_many_association.order(:id).destroy_all -> hooks into object.destroy
    ```
  - Real removal:
    
    ```
      ParanoidObject.scope.destroy!(object_id)
      paranoid_object.has_many_association.order(:id).destroy(has_many_association_object_id)
      paranoid_object.has_many_association.only_deleted.destroy(has_many_association_object_id)
      paranoid_object.has_many_association.order(:id).destroy_all
      paranoid_object.has_many_association.only_deleted.destroy_all
      paranoid_object.has_many_association.order(:id).delete_all!
    ```
- `with_deleted` and `only_deleted` are fully chainable with scopes and relations:
  
  ```
  Object.some_scope.with_deleted == Object.with_deleted.some_scope
  Object.only_deleted.where(..) == Object.where(..).only_deleted 
  ```
- Added `:with_deleted` option to `belongs_to` (taken from and modified slightly: https://github.com/goncalossilva/rails3_acts_as_paranoid/pull/48)
## 

Fixes:
- https://github.com/goncalossilva/rails3_acts_as_paranoid/issues/50
