### PR TITLE
Dependent deletion / recovery tests and fixes

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -134,11 +134,11 @@ module ActsAsParanoid
     end
     
     def destroy_dependent_associations!
-      self.class.dependent_associations.each do |association|
-        if association.collection? && self.send(association.name).paranoid?
-          association.klass.with_deleted.instance_eval("find_all_by_#{association.foreign_key}(#{self.id.to_json})").each do |object|
-            object.destroy!
-          end
+      self.class.dependent_associations.each do |reflection|
+        next unless reflection.klass.paranoid?
+
+        association(reflection.name).association_scope.each do |object|
+          object.destroy!
         end
       end
     end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -137,7 +137,12 @@ module ActsAsParanoid
       self.class.dependent_associations.each do |reflection|
         next unless reflection.klass.paranoid?
 
-        association(reflection.name).association_scope.each do |object|
+        scope = reflection.klass.only_deleted
+       
+        # Merge in the association's scope
+        scope = scope.merge(association(reflection.name).association_scope)
+
+        scope.each do |object|
           object.destroy!
         end
       end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -77,7 +77,7 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 1, ParanoidString.count
   end
 
-  def setup_recursive_recovery_tests
+  def setup_recursive_tests
     @paranoid_time_object = ParanoidTime.first
    
     # Create one extra ParanoidHasManyDependant record so that we can validate
@@ -113,9 +113,12 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 3, ParanoidHasOneDependant.count
     assert_equal 5, NotParanoid.count
     assert_equal 1, HasOneNotParanoid.count
+  end
+
+  def test_recursive_fake_removal
+    setup_recursive_tests
 
     @paranoid_time_object.destroy
-    @paranoid_time_object.reload
 
     assert_equal 2, ParanoidTime.count
     assert_equal 0, ParanoidHasManyDependant.count
@@ -127,7 +130,10 @@ class ParanoidTest < ParanoidBaseTest
   end
 
   def test_recursive_recovery
-    setup_recursive_recovery_tests
+    setup_recursive_tests
+
+    @paranoid_time_object.destroy
+    @paranoid_time_object.reload
 
     @paranoid_time_object.recover(:recursive => true)
 
@@ -141,7 +147,10 @@ class ParanoidTest < ParanoidBaseTest
   end
 
   def test_recursive_recovery_dependant_window
-    setup_recursive_recovery_tests
+    setup_recursive_tests
+
+    @paranoid_time_object.destroy
+    @paranoid_time_object.reload
 
     # Stop the following from recovering: 
     #   - ParanoidHasManyDependant and its ParanoidBelongsDependant 
@@ -162,7 +171,10 @@ class ParanoidTest < ParanoidBaseTest
   end
 
   def test_non_recursive_recovery
-    setup_recursive_recovery_tests
+    setup_recursive_tests
+
+    @paranoid_time_object.destroy
+    @paranoid_time_object.reload
 
     @paranoid_time_object.recover(:recursive => false)
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -82,7 +82,7 @@ class ParanoidTest < ParanoidBaseTest
    
     # Create one extra ParanoidHasManyDependant record so that we can validate
     # the correct dependants are recovered.
-    ParanoidTime.last.paranoid_has_many_dependants.create(:name => "should not be recovered").destroy
+    ParanoidTime.where('id IS NOT ?', @paranoid_time_object.id).first.paranoid_has_many_dependants.create(:name => "should not be recovered").destroy
 
     @paranoid_boolean_count = ParanoidBoolean.count
 
@@ -125,6 +125,20 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 0, ParanoidBelongsDependant.count
     assert_equal @paranoid_boolean_count, ParanoidBoolean.count
     assert_equal 0, ParanoidHasOneDependant.count
+    assert_equal 1, NotParanoid.count
+    assert_equal 0, HasOneNotParanoid.count
+  end
+
+  def test_recursive_real_removal
+    setup_recursive_tests 
+
+    @paranoid_time_object.destroy!
+
+    assert_equal 0, ParanoidTime.only_deleted.count
+    assert_equal 1, ParanoidHasManyDependant.only_deleted.count
+    assert_equal 0, ParanoidBelongsDependant.only_deleted.count
+    assert_equal 0, ParanoidBoolean.only_deleted.count
+    assert_equal 0, ParanoidHasOneDependant.only_deleted.count
     assert_equal 1, NotParanoid.count
     assert_equal 0, HasOneNotParanoid.count
   end


### PR DESCRIPTION
This pull adds some tests in uncovered areas:
- dependent recovery within window
- _real_ record removal in a recursive manner (`:dependent => :destroy`). 

The tests also flushed out an issue with `destroy_dependant_associations!`, which wasn't properly destroying non-collection based association dependents. The fix is included in this pull (7aa4e3cdb744287cd70ebd617e32cb03ac4b3bbd).
