### PR TITLE
Fix nil polymorphic, with_deleted, belongs_to

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use ruby-1.9.3-p194@rails3_acts_as_paranoid --create

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ rvm:
   - 1.9.2
   - 1.9.3
   - jruby-19mode
-  - rbx-19mode

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,5 @@
 # ActsAsParanoid
+[![Build Status](https://secure.travis-ci.org/pericles/rails3_acts_as_paranoid.png?branch=master)](http://travis-ci.org/pericles/rails3_acts_as_paranoid)
 
 A simple plugin which hides records instead of deleting them, being able to recover them.
 


### PR DESCRIPTION
When association is polymorphic and association is not set, finder should return nil

see https://github.com/goncalossilva/rails3_acts_as_paranoid/issues/61
