### PR TITLE
Fix nil polymorphic, with_deleted, belongs_to

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -13,7 +13,6 @@ module ActsAsParanoid
         result = belongs_to_without_deleted(target, options)
 
         if with_deleted
-          result.options[:with_deleted] = with_deleted
           class_eval <<-RUBY, __FILE__, __LINE__
             def #{target}_with_unscoped(*args)
               association = association(:#{target})

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -71,24 +71,6 @@ class AssociationsTest < ParanoidBaseTest
     assert_nil paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted(true)
   end
 
-  def test_belongs_to_options
-    paranoid_time = ParanoidHasManyDependant.reflections[:paranoid_time]
-    assert_equal :belongs_to, paranoid_time.macro
-    assert_nil paranoid_time.options[:with_deleted]
-  end
-
-  def test_belongs_to_with_deleted_options
-    paranoid_time_with_deleted = ParanoidHasManyDependant.reflections[:paranoid_time_with_deleted]
-    assert_equal :belongs_to, paranoid_time_with_deleted.macro
-    assert paranoid_time_with_deleted.options[:with_deleted]
-  end
-
-  def test_belongs_to_polymorphic_with_deleted_options
-    paranoid_time_polymorphic_with_deleted = ParanoidHasManyDependant.reflections[:paranoid_time_polymorphic_with_deleted]
-    assert_equal :belongs_to, paranoid_time_polymorphic_with_deleted.macro
-    assert paranoid_time_polymorphic_with_deleted.options[:with_deleted]
-  end
-
   def test_only_find_associated_records_when_finding_with_paranoid_deleted
     parent = ParanoidBelongsDependant.create
     child = ParanoidHasManyDependant.create


### PR DESCRIPTION
When association is polymorphic and association is not set, finder should return nil

see https://github.com/goncalossilva/rails3_acts_as_paranoid/issues/61
