### PR TITLE
Fixed default_scope issue.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,11 +102,29 @@ Once you retrieve data using `with_deleted` scope you can check deletion status 
     Paranoiac.create(:name => 'foo').destroy
     Paranoiac.with_deleted.first.deleted? #=> true
 
+### Associations
+Associations are also supported. From the simplest behaviors you'd expect to more nifty things like the ones mentioned previously or the usage of the `:with_deleted` option with `belongs_to`
+
+class ParanoiacParent < ActiveRecord::Base
+	has_many :children, :class_name => "ParanoiacChild"
+end
+
+class ParanoiacChild < ActiveRecord::Base
+	belongs_to :parent, :class_name => "ParanoiacParent"
+	belongs_to :parent_with_deleted, :class_name => "ParanoiacParent", :with_deleted => true
+end
+
+parent = ParanoiacParent.first
+child = parent.children.create
+parent.destroy
+
+child.parent #=> nil
+child.parent_with_deleted #=> ParanoiacParent (it works!)
+
 ## Caveats
 
 Watch out for these caveats:
 
--   You cannot use default\_scope in your model. It is possible to work around this caveat, but it's not pretty. Have a look at [this article](http://joshuaclayton.github.com/code/default_scope/activerecord/is_paranoid/multiple-default-scopes.html) if you really need to have your own default scope.
 -   You cannot use scopes named `with_deleted`, `only_deleted` and `paranoid_deleted_around_time`
 -   `unscoped` will return all records, deleted or not
 

--- a/lib/rails3_acts_as_paranoid.rb
+++ b/lib/rails3_acts_as_paranoid.rb
@@ -70,21 +70,15 @@ module ActsAsParanoid
     end
 
     def with_deleted
-      scope = self.scoped
-      where_values = scope.instance_variable_get(:'@where_values')
-
-      return self.unscoped unless where_values
-
-      where_values.delete(paranoid_default_scope_sql)
-      scope
+      without_paranoid_default_scope
     end
 
     def only_deleted
-      self.unscoped.where("#{paranoid_column_reference} IS NOT ?", nil)
+      without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
     end
 
     def delete_all!(conditions = nil)
-      self.unscoped.delete_all!(conditions)
+      without_paranoid_default_scope.delete_all!(conditions)
     end
 
     def delete_all(conditions = nil)
@@ -134,6 +128,19 @@ module ActsAsParanoid
 
       result
     end
+
+  protected
+
+    def without_paranoid_default_scope
+      scope = self.scoped
+      where_values = scope.instance_variable_get(:'@where_values')
+
+      return self.unscoped unless where_values
+
+      where_values.delete(paranoid_default_scope_sql)
+      scope
+    end
+
   end
   
   module InstanceMethods

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,6 +118,13 @@ def setup_db
       
       t.timestamps
     end
+
+    create_table :paranoid_humen do |t|
+      t.string   :gender
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
   end
 end
 
@@ -269,6 +276,11 @@ class ParanoidObserver < ActiveRecord::Observer
     self.called_before_recover = nil
     self.called_after_recover = nil
   end
+end
+
+class ParanoidHuman < ActiveRecord::Base
+  acts_as_paranoid
+  default_scope where('gender = ?', 'male')
 end
 
 ParanoidWithCallback.add_observer(ParanoidObserver.instance)


### PR DESCRIPTION
only_deleted method will find only associated records and won't break any default scopes. destroy_all! method will also take into account default scope. Updated README, but it still recommends version 0.0.9 for rails 3.0, which makes documentation little inconsistent.
