### PR TITLE
Fixing support for string type not to ignore records with column value other than the user-specified non-nil deleted_value

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ The values shown are the defaults. While *column* can be anything (as long as it
 - `time` or
 - `string`
 
-If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted").
+If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records not matching this string will be treated normally.
 
 ### Filtering
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -22,7 +22,11 @@ module ActsAsParanoid
       end
 
       def only_deleted
-        without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
+        if paranoid_column_type == :string && paranoid_configuration[:deleted_value]
+          without_paranoid_default_scope.where("#{paranoid_column_reference} IS ?", paranoid_configuration[:deleted_value])
+        else
+          without_paranoid_default_scope.where("#{paranoid_column_reference} IS NOT ?", nil)
+        end
       end
 
       def delete_all!(conditions = nil)
@@ -34,7 +38,11 @@ module ActsAsParanoid
       end
 
       def paranoid_default_scope_sql
-        self.scoped.table[paranoid_column].eq(nil).to_sql
+        if paranoid_column_type == :string && paranoid_configuration[:deleted_value]
+          self.scoped.table[paranoid_column].eq(nil).or(self.scoped.table[paranoid_column].not_eq(paranoid_configuration[:deleted_value])).to_sql
+        else
+          self.scoped.table[paranoid_column].eq(nil).to_sql
+        end
       end
 
       def paranoid_column

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -24,20 +24,20 @@ class ParanoidTest < ParanoidBaseTest
   def test_fake_removal
     assert_equal 3, ParanoidTime.count
     assert_equal 3, ParanoidBoolean.count
-    assert_equal 1, ParanoidString.count
+    assert_equal 2, ParanoidString.count
 
     ParanoidTime.first.destroy
     ParanoidBoolean.delete_all("name = 'paranoid' OR name = 'really paranoid'")
     ParanoidString.first.destroy
     assert_equal 2, ParanoidTime.count
     assert_equal 1, ParanoidBoolean.count
-    assert_equal 0, ParanoidString.count
+    assert_equal 1, ParanoidString.count
     assert_equal 1, ParanoidTime.only_deleted.count 
     assert_equal 2, ParanoidBoolean.only_deleted.count
     assert_equal 1, ParanoidString.only_deleted.count
     assert_equal 3, ParanoidTime.with_deleted.count
     assert_equal 3, ParanoidBoolean.with_deleted.count
-    assert_equal 1, ParanoidString.with_deleted.count
+    assert_equal 2, ParanoidString.with_deleted.count
   end
 
   def test_real_removal
@@ -46,10 +46,10 @@ class ParanoidTest < ParanoidBaseTest
     ParanoidString.first.destroy!
     assert_equal 2, ParanoidTime.count
     assert_equal 1, ParanoidBoolean.count
-    assert_equal 0, ParanoidString.count
+    assert_equal 1, ParanoidString.count
     assert_equal 2, ParanoidTime.with_deleted.count
     assert_equal 1, ParanoidBoolean.with_deleted.count
-    assert_equal 0, ParanoidString.with_deleted.count
+    assert_equal 1, ParanoidString.with_deleted.count
     assert_equal 0, ParanoidTime.only_deleted.count
     assert_equal 0, ParanoidBoolean.only_deleted.count
     assert_equal 0, ParanoidString.only_deleted.count
@@ -70,11 +70,11 @@ class ParanoidTest < ParanoidBaseTest
     ParanoidBoolean.only_deleted.first.recover
     assert_equal 3, ParanoidBoolean.count
 
-    assert_equal 1, ParanoidString.count
+    assert_equal 2, ParanoidString.count
     ParanoidString.first.destroy
-    assert_equal 0, ParanoidString.count
-    ParanoidString.with_deleted.first.recover
     assert_equal 1, ParanoidString.count
+    ParanoidString.with_deleted.first.recover
+    assert_equal 2, ParanoidString.count
   end
 
   def setup_recursive_tests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -355,6 +355,8 @@ class ParanoidBaseTest < ActiveSupport::TestCase
     end
 
     ParanoidString.create! :name => "strings can be paranoid"
+    ParanoidString.create! :name => "strings can be populated and not match deleted_value and in scope", :deleted => 'not dead yet'
+
     NotParanoid.create! :name => "no paranoid goals"
     ParanoidWithCallback.create! :name => "paranoid with callbacks"
 


### PR DESCRIPTION
This is to resolve: https://github.com/goncalossilva/rails3_acts_as_paranoid/issues/72

Summary:

Fixing support for specifying a non-nil deleted_value with string type, so that if the column contains a value other than the deleted_value, the record won't be considered to be deleted. Also added tests for this.

Explanation:

With this patch you can have values in the column like "not deleted" and the record would not be considered deleted, but if the value was the same as the deleted_value like "deleted" then the record would be considered deleted.

I would hope this would be backwards compatible with how people were using it, although if they had assumed that if any value was in the column that the record should be considered deleted, then this patch would not be backwards compatible. However, since I had gotten the impression that records not marked with the deleted_value were not deleted, my assumption is that this patch makes it behave more like users of the gem would expect.
