### PR TITLE
Unique constraint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -138,6 +138,30 @@ p2.save
 p1.recover #=> fails validation!
 ```
 
+Sometimes you have unique constraints in your database. They can be easily broken when you have record that was marked as deleted by ActsAsParanoid and you are creating new one with same values of unique fields. You can handle this situation by deleting old record.
+
+```ruby
+class Paranoiac < ActiveRecord::Base
+  acts_as_paranoid
+  ensure_unique_constraint_on :name  # 'name' is unique key
+end
+
+p1 = Paranoiac.create(:name => 'foo')
+p1.destroy
+
+p2 = Paranoiac.build(:name => 'foo')
+p2.save #=> true
+```
+
+You can provide several field names if you have multiple-column constraint.
+
+```ruby
+class Paranoiac < ActiveRecord::Base
+  acts_as_paranoid
+  ensure_unique_constraint_on :name, :code
+end
+```
+
 ### Status
 You can check the status of your paranoid objects with the `deleted?` helper
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -63,7 +63,7 @@ module ActsAsParanoid
 
         before_save do |record|
           values = fields.map { |f| record[f] }
-          old_record = record.class.with_deleted.send(method_name, *values)
+          old_record = record.class.only_deleted.send(method_name, *values)
           old_record.destroy! if old_record
         end
       end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -57,6 +57,17 @@ module ActsAsParanoid
         end
       end
 
+      def ensure_unique_constraint_on(*args)
+        fields = args
+        method_name = :"find_by_#{fields.join('_and_')}"
+
+        before_save do |record|
+          values = fields.map { |f| record[f] }
+          old_record = record.class.with_deleted.send(method_name, *values)
+          old_record.destroy! if old_record
+        end
+      end
+
     protected
 
       def without_paranoid_default_scope

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -293,4 +293,15 @@ class ParanoidTest < ParanoidBaseTest
     
     assert_paranoid_deletion(model)
   end
+
+  def test_ensure_unique_constraint_on
+    model = ParanoidWithUniqueConstraint.create(:unique_field => 'imoneandonly')
+    model.destroy
+
+    another = ParanoidWithUniqueConstraint.create(:unique_field => 'imoneandonly', :arbitrary_field => 'another')
+    assert another.persisted?
+
+    another = ParanoidWithUniqueConstraint.find_by_unique_field('imoneandonly')
+    assert_equal 'another', another.arbitrary_field
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,6 +166,15 @@ def setup_db
 
       t.timestamps
     end
+
+    create_table :paranoid_with_unique_constraints do |t|
+      t.string   :unique_field
+      t.string   :arbitrary_field
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+    add_index :paranoid_with_unique_constraints, :unique_field, :unique => true
   end
 end
 
@@ -408,4 +417,10 @@ end
 class ParanoidHuman < ActiveRecord::Base
   acts_as_paranoid
   default_scope where('gender IS ?', 'male')
+end
+
+class ParanoidWithUniqueConstraint < ActiveRecord::Base
+  acts_as_paranoid
+
+  ensure_unique_constraint_on :unique_field
 end


### PR DESCRIPTION
We have unique constraints in our database. They was broken when record was marked as deleted by ActsAsParanoid and we tried to create new one with same values of unique fields. I suggest to handle this situation by deleting old record.

Schema:

```
create_table :paranoid_with_unique_constraints do |t|
  t.string   :unique_field
  t.string   :arbitrary_field
  t.datetime :deleted_at

  t.timestamps
end
add_index :paranoid_with_unique_constraints, :unique_field, :unique => true
```

Model:

```
class ParanoidWithUniqueConstraint < ActiveRecord::Base
  acts_as_paranoid
  ensure_unique_constraint_on :unique_field
end
```

Test:

```
model = ParanoidWithUniqueConstraint.create(:unique_field => 'imoneandonly')
model.destroy

another = ParanoidWithUniqueConstraint.create(:unique_field => 'imoneandonly', :arbitrary_field => 'another')
another.persisted? # => true

another = ParanoidWithUniqueConstraint.find_by_unique_field('imoneandonly')
another.arbitrary_field # => 'another'
```
