### PR TITLE
Add support for string type with non-nil values when not deleted

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,6 +34,7 @@ The values shown are the defaults. While *column* can be anything (as long as it
 - `string`
 
 If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted").
+If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records not matching this string will be treated normally.
 
 ### Filtering
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -293,4 +293,44 @@ class ParanoidTest < ParanoidBaseTest
     
     assert_paranoid_deletion(model)
   end
+
+  # Test string type columns that don't have a nil value when not deleted (Y/N for example)
+  def test_string_type_with_no_nil_value_before_destroy
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 1, ParanoidString.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 0, ParanoidString.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_before_destroy_with_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 1, ParanoidString.with_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy_with_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 1, ParanoidString.with_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_before_destroy_only_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 0, ParanoidString.only_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy_only_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 1, ParanoidString.only_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroyed_twice
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    2.times { ps.destroy }
+    assert_equal 0, ParanoidString.with_deleted.where(:id => ps).count
+  end
 end


### PR DESCRIPTION
This is pretty much accomplishing the same thing as @garysweaver did with pull request #73.

There are two main differences:
- Make sure records with non-nil values in the deleted column are not actually deleted (for real) unless the column value matches the deleted_value. They will be deleted on a second destroy as expected.
- The tests added are isolated from the previously existing tests and do not modify the test setup. This was requested by @chuckg in reference to pull request #73.
