### PR TITLE
Composite Primary Keys Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,6 +34,7 @@ The values shown are the defaults. While *column* can be anything (as long as it
 - `string`
 
 If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted").
+If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records not matching this string will be treated normally.
 
 ### Filtering
 

--- a/README.markdown
+++ b/README.markdown
@@ -33,8 +33,7 @@ The values shown are the defaults. While *column* can be anything (as long as it
 - `time` or
 - `string`
 
-If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted").
-If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records not matching this string will be treated normally.
+If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records with a non-matching value in this column will be treated normally (ie: not deleted).
 
 ### Filtering
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,11 @@ desc 'Test the rails3_acts_as_paranoid plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
-  t.pattern = 'test/**/test_*.rb'
+
+  test_files = FileList['test/**/test_*.rb']
+  test_files.exclude('test/test_helper.rb')
+  t.test_files = test_files
+
   t.verbose = true
 end
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -89,7 +89,7 @@ module ActsAsParanoid
       with_transaction_returning_status do
         run_callbacks :destroy do
           destroy_dependent_associations!
-          self.class.delete_all!(self.class.primary_key.to_sym => self.id)
+          self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
           self.paranoid_value = self.class.delete_now_value
           freeze
         end
@@ -100,7 +100,7 @@ module ActsAsParanoid
       if !deleted?
         with_transaction_returning_status do
           run_callbacks :destroy do
-            self.class.delete_all(self.class.primary_key.to_sym => self.id)
+            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
             self.paranoid_value = self.class.delete_now_value
             self
           end

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -18,7 +18,11 @@ module ActsAsParanoid
         end
 
         relation = build_relation(finder_class, table, attribute, value)
-        relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
+        if record.persisted?
+          [Array(finder_class.primary_key),Array(record.send(:id))].transpose.each do |pk_key, pk_value|
+            relation = relation.and(table[pk_key.to_sym].not_eq(pk_value))
+          end
+        end
 
         Array.wrap(options[:scope]).each do |scope_item|
           scope_value = record.send(scope_item)

--- a/rails3_acts_as_paranoid.gemspec
+++ b/rails3_acts_as_paranoid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "rails3_acts_as_paranoid"
-  s.version           = "0.2.3"
+  s.version           = "0.2.4"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Goncalo Silva"]
   s.email             = ["goncalossilva@gmail.com"]

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -82,7 +82,7 @@ class ParanoidTest < ParanoidBaseTest
    
     # Create one extra ParanoidHasManyDependant record so that we can validate
     # the correct dependants are recovered.
-    ParanoidTime.where('id IS NOT ?', @paranoid_time_object.id).first.paranoid_has_many_dependants.create(:name => "should not be recovered").destroy
+    ParanoidTime.where('id <> ?', @paranoid_time_object.id).first.paranoid_has_many_dependants.create(:name => "should not be recovered").destroy
 
     @paranoid_boolean_count = ParanoidBoolean.count
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -293,4 +293,44 @@ class ParanoidTest < ParanoidBaseTest
     
     assert_paranoid_deletion(model)
   end
+
+  # Test string type columns that don't have a nil value when not deleted (Y/N for example)
+  def test_string_type_with_no_nil_value_before_destroy
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 1, ParanoidString.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 0, ParanoidString.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_before_destroy_with_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 1, ParanoidString.with_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy_with_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 1, ParanoidString.with_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_before_destroy_only_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    assert_equal 0, ParanoidString.only_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroy_only_deleted
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    ps.destroy
+    assert_equal 1, ParanoidString.only_deleted.where(:id => ps).count
+  end
+
+  def test_string_type_with_no_nil_value_after_destroyed_twice
+    ps = ParanoidString.create!(:deleted => 'not dead')
+    2.times { ps.destroy }
+    assert_equal 0, ParanoidString.with_deleted.where(:id => ps).count
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -394,7 +394,7 @@ class ParanoidForest < ActiveRecord::Base
   require "active_support/core_ext/logger.rb"
   ActiveRecord::Base.logger = Logger.new(StringIO.new)
 
-  scope :rainforest, where('rainforest IS ?', true)
+  scope :rainforest, where(:rainforest => true)
 
   has_many :paranoid_trees, :dependent => :destroy
 end
@@ -407,5 +407,5 @@ end
 
 class ParanoidHuman < ActiveRecord::Base
   acts_as_paranoid
-  default_scope where('gender IS ?', 'male')
+  default_scope where('gender = ?', 'male')
 end


### PR DESCRIPTION
Changed the way one interacts with the primary keys in order for it to support this gem: https://github.com/drnic/composite_primary_keys . When calling primary_key on a class it returns an array of keys instead of a key. As for the id call on an object, it returns an array of its primary key values. So, I just updated the 3 places where the primary key is being used to conform to this structure as well as with the expected standard case of one primary key. For this reason I didn't write specific tests for the composite case. 

This has the additional overhead of creating certain data structures to handle these cases, which I don't know if it could be a deal-breaker from your perspective. 

If indeed you see this as not really a support case you want to provide, could you at least isolate the way one handles the primary key, so that it becomes more easily patchable for the ones who want to support composite primary keys? 

Of course, we can discuss possible culprits before we reach a definite conclusion. 
