### PR TITLE
Composite Primary Keys Support

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -89,7 +89,7 @@ module ActsAsParanoid
       with_transaction_returning_status do
         run_callbacks :destroy do
           destroy_dependent_associations!
-          self.class.delete_all!(self.class.primary_key.to_sym => self.id)
+          self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
           self.paranoid_value = self.class.delete_now_value
           freeze
         end
@@ -100,7 +100,7 @@ module ActsAsParanoid
       if !deleted?
         with_transaction_returning_status do
           run_callbacks :destroy do
-            self.class.delete_all(self.class.primary_key.to_sym => self.id)
+            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
             self.paranoid_value = self.class.delete_now_value
             self
           end

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -18,7 +18,11 @@ module ActsAsParanoid
         end
 
         relation = build_relation(finder_class, table, attribute, value)
-        relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
+        if record.persisted?
+          [Array(finder_class.primary_key),Array(record.send(:id))].transpose.each do |pk_key, pk_value|
+            relation = relation.and(table[pk_key.to_sym].not_eq(pk_value))
+          end
+        end
 
         Array.wrap(options[:scope]).each do |scope_item|
           scope_value = record.send(scope_item)


### PR DESCRIPTION
Changed the way one interacts with the primary keys in order for it to support this gem: https://github.com/drnic/composite_primary_keys . When calling primary_key on a class it returns an array of keys instead of a key. As for the id call on an object, it returns an array of its primary key values. So, I just updated the 3 places where the primary key is being used to conform to this structure as well as with the expected standard case of one primary key. For this reason I didn't write specific tests for the composite case.

This has the additional overhead of creating certain data structures to handle these cases, which I don't know if it could be a deal-breaker from your perspective.

If indeed you see this as not really a support case you want to provide, could you at least isolate the way one handles the primary key, so that it becomes more easily patchable for the ones who want to support composite primary keys?

Of course, we can discuss possible culprits before we reach a definite conclusion.
