### PR TITLE
Remove table name from default scope sql queries

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -35,7 +35,7 @@ module ActsAsParanoid
     include ActsAsParanoid::Core
     
     # Magic!
-    default_scope { where(paranoid_default_scope_sql) }
+    default_scope :conditions => { :deleted_at => nil }
 
     # The paranoid column should not be mass-assignable
     attr_protected paranoid_configuration[:column]

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -39,11 +39,9 @@ module ActsAsParanoid
 
       def paranoid_default_scope_sql
         if string_type_with_deleted_value?
-          self.scoped.table[paranoid_column].eq(nil).
-            or(self.scoped.table[paranoid_column].not_eq(paranoid_configuration[:deleted_value])).
-            to_sql
+          "(\"#{paranoid_column}\" IS NULL OR \"#{paranoid_column}\" != '#{paranoid_configuration[:deleted_value]}')"
         else
-          self.scoped.table[paranoid_column].eq(nil).to_sql
+          "#{paranoid_column} IS NULL"
         end
       end
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -73,13 +73,15 @@ module ActsAsParanoid
 
       def without_paranoid_default_scope
         scope = self.scoped.with_default_scope
-        scope.where_values.each do |w|
-          if (w.is_a?(Arel::Nodes::Equality) && w.left.name == :deleted_at && w.right == nil) || (w.is_a?(String) && w == paranoid_default_scope_sql)
-            scope.where_values.delete w
-            break
+        index = scope.where_values.index do |w|
+          if w.is_a? Arel::Nodes::Equality
+            w.right == nil && w.left != nil && (w.left.name == :deleted_at || w.left.name == 'deleted_at')
+          elsif w.is_a? String
+            w == paranoid_default_scope_sql
           end
         end
 
+        scope.where_values.delete_at(index) if index
         scope
       end
     end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -73,7 +73,12 @@ module ActsAsParanoid
 
       def without_paranoid_default_scope
         scope = self.scoped.with_default_scope
-        scope.where_values.delete(paranoid_default_scope_sql)
+        scope.where_values.each do |w|
+          if (w.is_a?(Arel::Nodes::Equality) && w.left.name == :deleted_at && w.right == nil) || (w.is_a?(String) && w == paranoid_default_scope_sql)
+            scope.where_values.delete w
+            break
+          end
+        end
 
         scope
       end


### PR DESCRIPTION
Hi there,

I'm using `acts_as_paranoid` in a situation where I have an inheritance through MTI. I defined only the root model as `acts_as_paranoid`.

So, the problem is default_scope. The gem define (using Arel, in default use):

`default_scope { where('tablename'.'delete_at' IS NULL) }`.

When I try to fetch a subclass model, I got an error telling me `tablename` does not exists. And it is true. It doesn't. After a little debugging, I've found out it was because of the `default_scope` that was getting executed only when the root class was loaded (it uses the root class context).

I could get along with this changing the `default_scope` to something like this:

`default_scope :condition => { :deleted_at => nil }

This way, the condition gets executed every time somebody asks for a relation. It works in default case, but it doesn't where deleted_at is a string. I really tried something to make it, but I couldn't find a way.

Well, the only solution I came up into was changing the string condition, creating it manually (without Areal), so I could reproduce what's were built but without the table name. I know it can be dangerous in multi tabled queries, but I had no other option.

Please let me know if you have any other solution for my situation. I would be happy to make it better.

Regards,
Vieira
