### PR TITLE
Don't fail when trying to remove an unsaved object

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -106,7 +106,7 @@ module ActsAsParanoid
         with_transaction_returning_status do
           run_callbacks :destroy do
             # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
-            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
+            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose]) if persisted?
             self.paranoid_value = self.class.delete_now_value
             self
           end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -63,6 +63,10 @@ class ParanoidTest < ParanoidBaseTest
     assert_empty ParanoidTime.with_deleted.all
   end
 
+  def test_removal_not_persisted
+    assert ParanoidTime.new.destroy
+  end
+
   def test_recovery
     assert_equal 3, ParanoidBoolean.count
     ParanoidBoolean.first.destroy


### PR DESCRIPTION
When trying to destroy an unsaved object (this happens in some of our tests), acts as paranoid tries to remove the object, and calls it's id for that with

```
Array(self.class.primary_key), Array(self.id)].transpose
```

As `self.id` is nil, transpose can't work because the array is missing an entry.
And we don't need to run any sql query to remove an object if nothing has been saved into the database yet.
