### PR TITLE
Make the paranoid column a protected attribute

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -37,6 +37,9 @@ module ActsAsParanoid
     # Magic!
     default_scope { where(paranoid_default_scope_sql) }
 
+    # The paranoid column should not be mass-assignable
+    attr_protected paranoid_configuration[:column]
+
     if paranoid_configuration[:column_type] == 'time'
       scope :deleted_inside_time_window, lambda {|time, window|
         deleted_after_time((time - window)).deleted_before_time((time + window))


### PR DESCRIPTION
It should not be accessible with mass assignment
