### PR TITLE
Fix of element size differs. + Checking persisted

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -94,7 +94,7 @@ module ActsAsParanoid
         run_callbacks :destroy do
           destroy_dependent_associations!
           # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
-          self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
+          self.class.delete_all!(Hash[[Array.wrap(self.class.primary_key), Array.wrap(self.id)].transpose]) if persisted?
           self.paranoid_value = self.class.delete_now_value
           freeze
         end
@@ -106,7 +106,7 @@ module ActsAsParanoid
         with_transaction_returning_status do
           run_callbacks :destroy do
             # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
-            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
+            self.class.delete_all(Hash[[Array.wrap(self.class.primary_key), Array.wrap(self.id)].transpose]) if persisted?
             self.paranoid_value = self.class.delete_now_value
             self
           end


### PR DESCRIPTION
Error: **Element size differs (1 should be 2)**

Why?

Was:

```
>> Array(self.class.primary_key)
=> ["i", "d"]
```

Correct:

```
>> Array.wrap(self.class.primary_key)
=> ["id"]
```

I think this is Ruby 1.9.3 Issue.
