### PR TITLE
fixing belongs_to :meta_thing, :dependent => destroy, polymorphic => true

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -131,20 +131,20 @@ module ActsAsParanoid
         end
       end
     end
-
+    
     def recover_dependent_associations(window, options)
       self.class.dependent_associations.each do |reflection|
-        next unless reflection.klass.paranoid?
+        next unless (klass = get_reflection_class(reflection)).paranoid?
 
-        scope = reflection.klass.only_deleted
+        scope = klass.only_deleted
 
         # Merge in the association's scope
         scope = scope.merge(association(reflection.name).association_scope)
 
         # We can only recover by window if both parent and dependant have a
         # paranoid column type of :time.
-        if self.class.paranoid_column_type == :time && reflection.klass.paranoid_column_type == :time
-          scope = scope.merge(reflection.klass.deleted_inside_time_window(paranoid_value, window))
+        if self.class.paranoid_column_type == :time && klass.paranoid_column_type == :time
+          scope = scope.merge(klass.deleted_inside_time_window(paranoid_value, window))
         end
 
         scope.each do |object|
@@ -155,9 +155,9 @@ module ActsAsParanoid
 
     def destroy_dependent_associations!
       self.class.dependent_associations.each do |reflection|
-        next unless reflection.klass.paranoid?
+        next unless (klass = get_reflection_class(reflection)).paranoid?
 
-        scope = reflection.klass.only_deleted
+        scope = klass.only_deleted
 
         # Merge in the association's scope
         scope = scope.merge(association(reflection.name).association_scope)
@@ -176,6 +176,14 @@ module ActsAsParanoid
     alias_method :destroyed?, :deleted?
 
     private
+    
+    def get_reflection_class(reflection)
+      if reflection.macro == :belongs_to && reflection.options.include?(:polymorphic)
+        self.send(reflection.foreign_type).constantize
+      else
+        reflection.klass
+      end
+    end
 
     def paranoid_value=(value)
       self.send("#{self.class.paranoid_column}=", value)

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -202,6 +202,43 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 1, NotParanoid.count
     assert_equal 0, HasOneNotParanoid.count
   end
+  
+  def test_recursive_recovery_for_belongs_to_polymorphic
+    child_1 = ParanoidAndroid.create
+    section_1 = ParanoidSection.create(:paranoid_thing => child_1)
+    
+    child_2 = ParanoidHuman.create(:gender => 'male')
+    section_2 = ParanoidSection.create(:paranoid_thing => child_2)
+    
+    assert_equal section_1.paranoid_thing, child_1
+    assert_equal section_1.paranoid_thing.class, ParanoidAndroid
+    assert_equal section_2.paranoid_thing, child_2
+    assert_equal section_2.paranoid_thing.class, ParanoidHuman
+    
+    parent = ParanoidTime.create(:name => "paranoid_parent")
+    parent.paranoid_sections << section_1
+    parent.paranoid_sections << section_2
+    
+    assert_equal 4, ParanoidTime.count
+    assert_equal 2, ParanoidSection.count
+    assert_equal 1, ParanoidAndroid.count
+    assert_equal 1, ParanoidHuman.count
+    
+    parent.destroy
+    
+    assert_equal 3, ParanoidTime.count
+    assert_equal 0, ParanoidSection.count
+    assert_equal 0, ParanoidAndroid.count
+    assert_equal 0, ParanoidHuman.count
+    
+    parent.reload
+    parent.recover
+    
+    assert_equal 4, ParanoidTime.count
+    assert_equal 2, ParanoidSection.count
+    assert_equal 1, ParanoidAndroid.count
+    assert_equal 1, ParanoidHuman.count
+  end
 
   def test_non_recursive_recovery
     setup_recursive_tests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,6 +166,17 @@ def setup_db
 
       t.timestamps
     end
+    
+    create_table :paranoid_androids do |t|
+      t.datetime :deleted_at
+    end
+    
+    create_table :paranoid_sections do |t|
+      t.integer   :paranoid_time_id
+      t.integer   :paranoid_thing_id
+      t.string    :paranoid_thing_type
+      t.datetime :deleted_at
+    end
   end
 end
 
@@ -183,6 +194,7 @@ class ParanoidTime < ActiveRecord::Base
   has_many :paranoid_has_many_dependants, :dependent => :destroy
   has_many :paranoid_booleans, :dependent => :destroy
   has_many :not_paranoids, :dependent => :delete_all
+  has_many :paranoid_sections, :dependent => :destroy
 
   has_one :has_one_not_paranoid, :dependent => :destroy
 
@@ -413,4 +425,14 @@ end
 class ParanoidHuman < ActiveRecord::Base
   acts_as_paranoid
   default_scope where('gender = ?', 'male')
+end
+
+class ParanoidAndroid < ActiveRecord::Base
+  acts_as_paranoid
+end
+
+class ParanoidSection < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_time
+  belongs_to :paranoid_thing, :polymorphic => true, :dependent => :destroy
 end


### PR DESCRIPTION
Instead of trying to constantize the name of the relationship (i.e. meta_thing) by calling reflection.klass (and possibly getting a bug for unknown class Parent::MetaThing), we can look to the reflection's foreign_type on polymorphic associations, and constantize that to use for determining the scope when recovering and destroying deleted_at objects.

All the tests passed, and it helped fix our use case for this gem.
