### PR TITLE
Restore objects without validation procedure

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -126,8 +126,7 @@ module ActsAsParanoid
         run_callbacks :recover do
           recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
-          self.paranoid_value = nil
-          self.save
+          update_attribute self.class.paranoid_column, nil # save without model validations
         end
       end
     end


### PR DESCRIPTION
In the current state recover method uses save to update paranoid_column, which causes ActiveRecord validations to be processed. So if deleted object was in invalid state, recover will fail.
I have replaced save call to update_attribute in order to solve this.
