### PR TITLE
add option for never deleting records from db

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -111,7 +111,7 @@ module ActsAsParanoid
             self
           end
         end
-      else
+      elsif !paranoid_configuration[:never_delete]
         destroy!
       end
     end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -352,4 +352,10 @@ class ParanoidTest < ParanoidBaseTest
     2.times { ps.destroy }
     assert_equal 0, ParanoidString.with_deleted.where(:id => ps).count
   end
+
+  def test_string_type_destroyed_twice_but_never_deleted
+    ps = ParanoidStringNeverDeleted.create!(:deleted => 'not dead')
+    2.times { ps.destroy }
+    assert_equal 1, ParanoidStringNeverDeleted.with_deleted.where(:id => ps).count
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,11 @@ def setup_db
       t.string    :deleted
     end
 
+    create_table :paranoid_string_never_deleteds do |t|
+      t.string    :name
+      t.string    :deleted
+    end
+
     create_table :not_paranoids do |t|
       t.string    :name
       t.integer   :paranoid_time_id
@@ -200,6 +205,10 @@ end
 
 class ParanoidString < ActiveRecord::Base
   acts_as_paranoid :column_type => "string", :column => "deleted", :deleted_value => "dead"
+end
+
+class ParanoidStringNeverDeleted < ActiveRecord::Base
+  acts_as_paranoid :column_type => "string", :column => "deleted", :deleted_value => "dead", :never_delete => true
 end
 
 class NotParanoid < ActiveRecord::Base


### PR DESCRIPTION
The default behavior of the gem will delete records when destroy is called twice. I added an option, :never_delete, so a record will never be deleted from the database by calling destroy.

I don't really like the name of the option, but I couldn't think of anything better. I'm open to other ideas.
