### PR TITLE
Added feature that lets "deleted_at" column handle UNIX time

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -26,7 +26,7 @@ module ActsAsParanoid
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!(options) # user options
 
-    raise ArgumentError, "'time', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
+    raise ArgumentError, "'time', 'integer', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'integer', 'boolean', 'string'].include? paranoid_configuration[:column_type]
 
     self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
     

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -66,6 +66,7 @@ module ActsAsParanoid
       def delete_now_value
         case paranoid_configuration[:column_type]
         when "time" then Time.now
+        when "integer" then Time.now.to_i
         when "boolean" then true
         when "string" then paranoid_configuration[:deleted_value]
         end


### PR DESCRIPTION
Added feature that lets "deleted_at" column handle UNIX time when supplied option {:column_type => 'integer'}. UNIX timestamp (integer) will inserted into the DB's "deleted_at" column just like "created_at/updated_at" column if the DB columns are defined as INT.
