### PR TITLE
ActiveRecord queries with includes now respect :with_deleted => true

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -5,6 +5,7 @@ require 'acts_as_paranoid/core'
 require 'acts_as_paranoid/associations'
 require 'acts_as_paranoid/validations'
 require 'acts_as_paranoid/relation'
+require 'acts_as_paranoid/preloader_association'
 
 
 module ActsAsParanoid
@@ -62,3 +63,6 @@ ActiveRecord::Relation.send :include, ActsAsParanoid::Relation
 
 # Push the recover callback onto the activerecord callback list
 ActiveRecord::Callbacks::CALLBACKS.push(:before_recover, :after_recover)
+
+# Use with_deleted in preloader build_scope
+ActiveRecord::Associations::Preloader::Association.send :include, ActsAsParanoid::PreloaderAssociation

--- a/lib/acts_as_paranoid/preloader_association.rb
+++ b/lib/acts_as_paranoid/preloader_association.rb
@@ -1,0 +1,15 @@
+module ActsAsParanoid
+  module PreloaderAssociation
+    def self.included(base)
+      base.class_eval do
+        def build_scope_with_deleted
+          scope = build_scope_without_deleted
+          scope = scope.with_deleted if options[:with_deleted] && klass.respond_to?(:with_deleted)
+          scope
+        end
+
+        alias_method_chain :build_scope, :deleted
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,6 +166,29 @@ def setup_db
 
       t.timestamps
     end
+
+    create_table :paranoid_belongs_to_polymorphics do |t|
+      t.string :name
+      t.string :parent_type
+      t.integer :parent_id
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    create_table :not_paranoid_has_many_as_parents do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_table :paranoid_has_many_as_parents do |t|
+      t.string :name
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
   end
 end
 
@@ -346,6 +369,21 @@ end
 class ParanoidWithScopedValidation < ActiveRecord::Base
   acts_as_paranoid
   validates_uniqueness_of :name, :scope => :category
+end
+
+
+class ParanoidBelongsToPolymorphic < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :parent, :polymorphic => true, :with_deleted => true
+end
+
+class NotParanoidHasManyAsParent < ActiveRecord::Base
+  has_many :paranoid_belongs_to_polymorphics, :as => :parent, :dependent => :destroy
+end
+
+class ParanoidHasManyAsParent < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :paranoid_belongs_to_polymorphics, :as => :parent, :dependent => :destroy
 end
 
 ParanoidWithCallback.add_observer(ParanoidObserver.instance)

--- a/test/test_preloader_association.rb
+++ b/test/test_preloader_association.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class PreloaderAssociationTest < ParanoidBaseTest
+  def test_includes_with_deleted
+    paranoid_time = ParanoidTime.first
+    paranoid_has_many_dependant = paranoid_time.paranoid_has_many_dependants.create(:name => 'dependant!')
+
+    paranoid_time.destroy
+
+    ParanoidHasManyDependant.with_deleted.includes(:paranoid_time_with_deleted).each do |hasmany|
+      assert_not_nil hasmany.paranoid_time_with_deleted
+    end
+  end
+
+  def test_includes_with_deleted_with_polymorphic_parent
+    not_paranoid_parent = NotParanoidHasManyAsParent.create(name: 'not paranoid parent')
+    paranoid_parent = ParanoidHasManyAsParent.create(name: 'paranoid parent')
+    ParanoidBelongsToPolymorphic.create(:name => 'belongs_to', :parent => not_paranoid_parent)
+    ParanoidBelongsToPolymorphic.create(:name => 'belongs_to', :parent => paranoid_parent)
+
+    paranoid_parent.destroy
+
+    ParanoidBelongsToPolymorphic.with_deleted.includes(:parent).each do |hasmany|
+      assert_not_nil hasmany.parent
+    end
+  end
+end


### PR DESCRIPTION
Check for with_deleted option when building scope for includes.  Fixes #62 
