### PR TITLE
add option to not use default scope.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,8 @@ The values shown are the defaults. While *column* can be anything (as long as it
 
 If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records with a non-matching value in this column will be treated normally (ie: not deleted).
 
+
+
 ### Filtering
 
 If a record is deleted by ActsAsParanoid, it won't be retrieved when accessing the database. So, `Paranoiac.all` will **not** include the deleted_records. if you want to access them, you have 2 choices:
@@ -51,6 +53,12 @@ time = Time.now
 
 Paranoiac.deleted_after_time(time)
 Paranoiac.deleted_before_time(time)
+
+If you specify `:no_default_scope` option
+
+- `:no_default_scope	=> true`
+
+queries will not be scoped by default. You can use `:no_deleted` scope if you want to retrive not deleted records.
 
 # Or roll it all up and get a nice window:
 Paranoiac.deleted_inside_time_window(time, 2.minutes)

--- a/README.markdown
+++ b/README.markdown
@@ -54,15 +54,14 @@ time = Time.now
 Paranoiac.deleted_after_time(time)
 Paranoiac.deleted_before_time(time)
 
+# Or roll it all up and get a nice window:
+Paranoiac.deleted_inside_time_window(time, 2.minutes)
+```
 If you specify `:no_default_scope` option
 
 - `:no_default_scope	=> true`
 
 queries will not be scoped by default. You can use `:no_deleted` scope if you want to retrive not deleted records.
-
-# Or roll it all up and get a nice window:
-Paranoiac.deleted_inside_time_window(time, 2.minutes)
-```
 
 ### Real deletion
 

--- a/README.markdown
+++ b/README.markdown
@@ -35,8 +35,6 @@ The values shown are the defaults. While *column* can be anything (as long as it
 
 If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records with a non-matching value in this column will be treated normally (ie: not deleted).
 
-
-
 ### Filtering
 
 If a record is deleted by ActsAsParanoid, it won't be retrieved when accessing the database. So, `Paranoiac.all` will **not** include the deleted_records. if you want to access them, you have 2 choices:

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -22,7 +22,7 @@ module ActsAsParanoid
     
     class_attribute :paranoid_configuration, :paranoid_column_reference
     
-    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes }
+    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :no_default_scope => false }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!(options) # user options
 
@@ -35,7 +35,11 @@ module ActsAsParanoid
     include ActsAsParanoid::Core
     
     # Magic!
-    default_scope { where(paranoid_default_scope_sql) }
+    if paranoid_configuration[:no_default_scope]
+      scope :no_deleted, where(paranoid_default_scope_sql)
+    else
+      default_scope { where(paranoid_default_scope_sql) }
+    end
 
     # The paranoid column should not be mass-assignable
     attr_protected paranoid_configuration[:column] unless paranoid_configuration[:mass_assignable]


### PR DESCRIPTION
I have a situation when I want all behavior of acts_as_paranoid but don't want to scope records by default.

I have added option to not use default scope and add scope to retrieve not deleted records only.

Default option is false to not break any current behavior.
