### PR TITLE
Rails 4 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 .bundle
 .DS_Store
+.idea

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -2,11 +2,11 @@ Gem::Specification.new do |s|
   s.name                  = "acts_as_paranoid"
   s.version               = "0.0.0"
   s.platform              = Gem::Platform::RUBY
-  s.authors               = ["Pete Michaud", "Goncalo Silva", "Charles G.", "Rick Olson"]
-  s.email                 = ["me@petermichaud.com"]
-  s.homepage              = "https://github.com/petemichaud/acts_as_paranoid"
-  s.summary               = "Active Record (~>4) plugin which allows you to hide and restore records without actually deleting them."
-  s.description           = "Active Record (~>4) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
+  s.authors               = ["Goncalo Silva", "Charles G.", "Rick Olson"]
+  s.email                 = ["goncalossilva@gmail.com"]
+  s.homepage              = "https://github.com/goncalossilva/rails3_acts_as_paranoid"
+  s.summary               = "Active Record (~>4.0) plugin which allows you to hide and restore records without actually deleting them."
+  s.description           = "Active Record (~>4.0) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project     = s.name
 
   s.required_rubygems_version = ">= 1.3.6"

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -2,16 +2,16 @@ Gem::Specification.new do |s|
   s.name                  = "acts_as_paranoid"
   s.version               = "0.0.0"
   s.platform              = Gem::Platform::RUBY
-  s.authors               = ["Goncalo Silva", "Charles G.", "Rick Olson"]
-  s.email                 = ["goncalossilva@gmail.com"]
-  s.homepage              = "https://github.com/goncalossilva/rails3_acts_as_paranoid"
-  s.summary               = "Active Record (~>3.2) plugin which allows you to hide and restore records without actually deleting them."
-  s.description           = "Active Record (~>3.2) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
+  s.authors               = ["Pete Michaud", "Goncalo Silva", "Charles G.", "Rick Olson"]
+  s.email                 = ["me@petermichaud.com"]
+  s.homepage              = "https://github.com/petemichaud/acts_as_paranoid"
+  s.summary               = "Active Record (~>4) plugin which allows you to hide and restore records without actually deleting them."
+  s.description           = "Active Record (~>4) plugin which allows you to hide and restore records without actually deleting them. Check its GitHub page for more in-depth information."
   s.rubyforge_project     = s.name
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "activerecord", "~> 3.2"
+  s.add_dependency "activerecord", "~> 4.0"
 
   s.files        = Dir["{lib}/**/*.rb", "LICENSE", "*.markdown"]
 end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -39,11 +39,11 @@ module ActsAsParanoid
 
       def paranoid_default_scope_sql
         if string_type_with_deleted_value?
-          self.scoped.table[paranoid_column].eq(nil).
-            or(self.scoped.table[paranoid_column].not_eq(paranoid_configuration[:deleted_value])).
+          self.all.table[paranoid_column].eq(nil).
+            or(self.all.table[paranoid_column].not_eq(paranoid_configuration[:deleted_value])).
             to_sql
         else
-          self.scoped.table[paranoid_column].eq(nil).to_sql
+          self.all.table[paranoid_column].eq(nil).to_sql
         end
       end
 
@@ -74,7 +74,7 @@ module ActsAsParanoid
     protected
 
       def without_paranoid_default_scope
-        scope = self.scoped.with_default_scope
+        scope = self.all.with_default_scope
         scope.where_values.delete(paranoid_default_scope_sql)
 
         scope

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -34,7 +34,7 @@ module ActsAsParanoid
       end
 
       def delete_all(conditions = nil)
-        update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value], conditions
+        where(conditions).update_all ["#{paranoid_configuration[:column]} = ?", delete_now_value]
       end
 
       def paranoid_default_scope_sql

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -126,8 +126,8 @@ module ActsAsParanoid
         run_callbacks :recover do
           recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
-          self.paranoid_value = nil
-          self.save
+          self.update_column(self.class.paranoid_column, nil)
+
         end
       end
     end

--- a/lib/acts_as_paranoid/relation.rb
+++ b/lib/acts_as_paranoid/relation.rb
@@ -21,7 +21,7 @@ module ActsAsParanoid
         
         def delete_all(conditions = nil)
           if paranoid?
-            update_all(paranoid_deletion_attributes, conditions)
+            where(conditions).update_all(paranoid_deletion_attributes)
           else
             delete_all!(conditions)
           end


### PR DESCRIPTION
I made some changes to support rails 4, and it appears to working correctly without deprecation warnings, but I could not get the test suite to load (it has some deprecated stuff in there that I'm not familiar with, and it says I don't have Bundler installed even though I do). So this need to be legitimately tested, but it works in my project, so I think it's probably close if not there already. 

I also changed some behavior that may be controversial. The change might be good as an option, actually.  on ln 129 of `core.rb` I changed it to use self.update_column, and as a result the deleted_at columns are reverted to nil, but no active record callbacks take place. This is the behavior I needed in my project, and it may be the correct behavior in general, but I'm not sure. Like I said, it could also be an option like `:recover_with_callbacks` or something like that.
