### PR TITLE
fix recover counter_cache does't change bug

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -189,7 +189,7 @@ module ActsAsParanoid
 
     def recover_counter_cache
       self.class.reflect_on_all_associations.select{ |reflection| reflection.options[:counter_cache] && reflection.macro == :belongs_to }.each do |reflection|
-        reflection.klass.with_deleted.increment_counter(reflection.counter_cache_column, send(reflection.foreign_key))
+        get_reflection_class(reflection).with_deleted.increment_counter(reflection.counter_cache_column, send(reflection.foreign_key))
       end
     end
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -189,7 +189,9 @@ module ActsAsParanoid
 
     def recover_counter_cache
       self.class.reflect_on_all_associations.select{ |reflection| reflection.options[:counter_cache] && reflection.macro == :belongs_to }.each do |reflection|
-        get_reflection_class(reflection).with_deleted.increment_counter(reflection.counter_cache_column, send(reflection.foreign_key))
+        klass = get_reflection_class(reflection)
+        scope = klass.paranoid? ? klass.with_deleted : klass
+        scope.increment_counter(reflection.counter_cache_column, send(reflection.foreign_key))
       end
     end
 

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -33,7 +33,7 @@ class AssociationsTest < ParanoidBaseTest
   end
 
   def test_belongs_to_with_deleted
-    paranoid_time = ParanoidTime.first 
+    paranoid_time = ParanoidTime.first
     paranoid_has_many_dependant = paranoid_time.paranoid_has_many_dependants.create(:name => 'dependant!')
 
     assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time
@@ -46,7 +46,7 @@ class AssociationsTest < ParanoidBaseTest
   end
 
   def test_belongs_to_polymorphic_with_deleted
-    paranoid_time = ParanoidTime.first 
+    paranoid_time = ParanoidTime.first
     paranoid_has_many_dependant = ParanoidHasManyDependant.create!(:name => 'dependant!', :paranoid_time_polymorphic_with_deleted => paranoid_time)
 
     assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time
@@ -56,6 +56,27 @@ class AssociationsTest < ParanoidBaseTest
 
     assert_nil paranoid_has_many_dependant.paranoid_time(true)
     assert_equal paranoid_time, paranoid_has_many_dependant.paranoid_time_polymorphic_with_deleted(true)
+  end
+
+  def test_belongs_to_counter_cache
+    n = 10
+    paranoid_time = ParanoidTime.first
+    n.times do
+      paranoid_time.paranoid_has_many_dependants.create!(:name => 'dependent!')
+    end
+    assert_equal n, paranoid_time.reload.counter
+
+    paranoid_time.paranoid_has_many_dependants.destroy_all
+    assert_equal 0, paranoid_time.reload.counter
+
+    paranoid_time.paranoid_has_many_dependants.with_deleted.each { |d| d.recover }
+    assert_equal n, paranoid_time.reload.counter
+
+    paranoid_time.destroy
+    assert_equal 0, paranoid_time.reload.counter
+
+    paranoid_time.recover
+    assert_equal n, paranoid_time.reload.counter
   end
 
   def test_belongs_to_nil_polymorphic_with_deleted

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ def setup_db
       t.datetime  :deleted_at
       t.integer   :paranoid_belongs_dependant_id
       t.integer   :not_paranoid_id
+      t.integer   :counter
 
       t.timestamps
     end
@@ -74,52 +75,52 @@ def setup_db
 
       t.timestamps
     end
-    
+
     create_table :paranoid_with_callbacks do |t|
       t.string    :name
       t.datetime  :deleted_at
-      
+
       t.timestamps
     end
 
     create_table :paranoid_destroy_companies do |t|
       t.string :name
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :paranoid_delete_companies do |t|
       t.string :name
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :paranoid_products do |t|
       t.integer :paranoid_destroy_company_id
       t.integer :paranoid_delete_company_id
       t.string :name
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :super_paranoids do |t|
       t.string :type
       t.references :has_many_inherited_super_paranoidz
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :has_many_inherited_super_paranoidzs do |t|
       t.references :super_paranoidz
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :paranoid_many_many_parent_lefts do |t|
       t.string :name
       t.timestamps
@@ -129,14 +130,14 @@ def setup_db
       t.string :name
       t.timestamps
     end
-    
+
     create_table :paranoid_many_many_children do |t|
       t.integer :paranoid_many_many_parent_left_id
       t.integer :paranoid_many_many_parent_right_id
       t.datetime :deleted_at
       t.timestamps
     end
-    
+
     create_table :paranoid_with_scoped_validations do |t|
       t.string :name
       t.string :category
@@ -148,15 +149,15 @@ def setup_db
       t.string   :name
       t.boolean  :rainforest
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
-    
+
     create_table :paranoid_trees do |t|
       t.integer  :paranoid_forest_id
       t.string   :name
       t.datetime :deleted_at
-      
+
       t.timestamps
     end
 
@@ -166,11 +167,11 @@ def setup_db
 
       t.timestamps
     end
-    
+
     create_table :paranoid_androids do |t|
       t.datetime :deleted_at
     end
-    
+
     create_table :paranoid_sections do |t|
       t.integer   :paranoid_time_id
       t.integer   :paranoid_thing_id
@@ -228,7 +229,7 @@ end
 
 class ParanoidHasManyDependant < ActiveRecord::Base
   acts_as_paranoid
-  belongs_to :paranoid_time
+  belongs_to :paranoid_time, :counter_cache => :counter
   belongs_to :paranoid_time_with_deleted, :class_name => 'ParanoidTime', :foreign_key => :paranoid_time_id, :with_deleted => true
   belongs_to :paranoid_time_polymorphic_with_deleted, :class_name => 'ParanoidTime', :foreign_key => :paranoid_time_id, :polymorphic => true, :with_deleted => true
 
@@ -249,31 +250,31 @@ end
 
 class ParanoidWithCallback < ActiveRecord::Base
   acts_as_paranoid
-  
+
   attr_accessor :called_before_destroy, :called_after_destroy, :called_after_commit_on_destroy
   attr_accessor :called_before_recover, :called_after_recover
-  
+
   before_destroy :call_me_before_destroy
   after_destroy :call_me_after_destroy
-  
+
   after_commit :call_me_after_commit_on_destroy, :on => :destroy
 
   before_recover :call_me_before_recover
   after_recover :call_me_after_recover
-  
+
   def initialize(*attrs)
     @called_before_destroy = @called_after_destroy = @called_after_commit_on_destroy = false
     super(*attrs)
   end
-  
+
   def call_me_before_destroy
     @called_before_destroy = true
   end
-  
+
   def call_me_after_destroy
     @called_after_destroy = true
   end
-  
+
   def call_me_after_commit_on_destroy
     @called_after_commit_on_destroy = true
   end
@@ -381,17 +382,17 @@ class ParanoidBaseTest < ActiveSupport::TestCase
   def teardown
     teardown_db
   end
-  
+
   def assert_empty(collection)
     assert(collection.respond_to?(:empty?) && collection.empty?)
   end
-  
+
   def assert_paranoid_deletion(model)
     row = find_row(model)
     assert_not_nil row, "#{model.class} entirely deleted"
     assert_not_nil row["deleted_at"], "Deleted at not set"
   end
-  
+
   def assert_non_paranoid_deletion(model)
     row = find_row(model)
     assert_nil row, "#{model.class} still exists"


### PR DESCRIPTION
Hi,

In my project, I found a strange phenomenon.

``` ruby
class A < AR:Base
  has_many :bs, dependent: :destroy
  attr_accessible :name
end

class B < AR:Base
  belongs_to :a, counter_cache: :counter
  attr_accessible :name
end

a = A.create!(name: 'a')
100.times do
  a.bs.create!(name: 'b')
end

a.counter
# => 100

a.destroy
a.counter
# => 0 No problem

a.recover
a.counter
# => 0 I think it's a bug

a.destroy
a.counter
# => -100
```

That is because destroy method is wrapped by destroy callbacks
buy default recover callbacks has no logic about the counter_cache
CR please!
Thank you 
- david
