### PR TITLE
Fixed recovery order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source "http://rubygems.org"
 gem "activerecord", "~>3.2"
 
 # Development dependencies
-gem "rake"
+gem "rake", "10.1.1"
 gem "activesupport", "~>3.2"
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "1.3.9"
 end
 
 platforms :jruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
     jdbc-sqlite3 (3.7.2.1)
     minitest (2.12.1)
     multi_json (1.3.4)
-    rake (0.9.2.2)
-    sqlite3 (1.3.6)
+    rake (10.1.1)
+    sqlite3 (1.3.9)
     tzinfo (0.3.33)
 
 PLATFORMS
@@ -37,5 +37,5 @@ DEPENDENCIES
   activesupport (~> 3.2)
   autotest-growl
   minitest
-  rake
-  sqlite3
+  rake (= 10.1.1)
+  sqlite3 (= 1.3.9)

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ rescue LoadError
   $stderr.puts "You need to have Bundler installed to be able build this gem."
 end
 require "rake/testtask"
-require "rake/rdoctask"
+require "rdoc/task"
 
 gemspec = eval(File.read(Dir["*.gemspec"].first))
 

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -42,8 +42,8 @@ module ActsAsParanoid
         deleted_after_time((time - window)).deleted_before_time((time + window))
       }
 
-      scope :deleted_after_time, lambda  { |time| where("#{paranoid_column} > ?", time) }
-      scope :deleted_before_time, lambda { |time| where("#{paranoid_column} < ?", time) }
+      scope :deleted_after_time, lambda  { |time| where("#{self.table_name}.#{paranoid_column} > ?", time) }
+      scope :deleted_before_time, lambda { |time| where("#{self.table_name}.#{paranoid_column} < ?", time) }
     end
   end
 end

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -22,7 +22,7 @@ module ActsAsParanoid
     
     class_attribute :paranoid_configuration, :paranoid_column_reference
     
-    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes }
+    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :dependent_destroy_paranoid_only => false }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!(options) # user options
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -108,11 +108,17 @@ module ActsAsParanoid
     def destroy
       if !deleted?
         with_transaction_returning_status do
-          run_callbacks :destroy do
-            # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
-            self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose]) if persisted?
+          if self.class.paranoid_configuration[:dependent_destroy_paranoid_only]
+            destroy_paranoid_associations
             self.paranoid_value = self.class.delete_now_value
-            self
+            self.save!
+          else
+            run_callbacks :destroy do
+              # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
+              self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose]) if persisted?
+              self.paranoid_value = self.class.delete_now_value
+              self
+            end
           end
         end
       else
@@ -175,6 +181,22 @@ module ActsAsParanoid
         end
       else 
         scope.update_all(self.class.paranoid_column => nil)
+      end
+    end
+
+    def destroy_paranoid_associations
+      self.class.dependent_associations.each do |reflection|
+        if reflection.klass.paranoid?
+          dependent_type = reflection.options[:dependent]
+          association_scope = association(reflection.name).association_scope
+          if dependent_type == :destroy
+            association_scope.each do |object|
+              object.send(reflection.options[:dependent])
+            end
+          elsif dependent_type == :delete_all
+            association_scope.delete_all
+          end
+        end
       end
     end
 

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -169,8 +169,12 @@ module ActsAsParanoid
         scope = scope.merge(klass.deleted_inside_time_window(paranoid_original_value, window))
       end
 
-      scope.each do |object|
-        object.recover(options)
+      unless reflection.options[:dependent] == :delete_all
+        scope.each do |object|
+          object.recover(options)
+        end
+      else 
+        scope.update_all(self.class.paranoid_column => nil)
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,14 +119,24 @@ def setup_db
       
       t.timestamps
     end
+
+    create_table :paranoid_many_many_super_parents do |t|
+      t.string :name
+      t.datetime :deleted_at
+      t.timestamps
+    end
     
     create_table :paranoid_many_many_parent_lefts do |t|
       t.string :name
+      t.integer :paranoid_many_many_super_parent_id
+      t.datetime :deleted_at
       t.timestamps
     end
 
     create_table :paranoid_many_many_parent_rights do |t|
       t.string :name
+      t.integer :paranoid_many_many_super_parent_id
+      t.datetime :deleted_at
       t.timestamps
     end
     
@@ -339,13 +349,23 @@ class ParanoidObserver < ActiveRecord::Observer
 end
 
 
+class ParanoidManyManySuperParent < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :paranoid_many_many_parent_left, dependent: :destroy
+  has_many :paranoid_many_many_parent_right, dependent: :destroy
+end
+
 class ParanoidManyManyParentLeft < ActiveRecord::Base
-  has_many :paranoid_many_many_children
+  acts_as_paranoid
+  belongs_to :paranoid_many_many_super_parent
+  has_many :paranoid_many_many_children, dependent: :destroy
   has_many :paranoid_many_many_parent_rights, :through => :paranoid_many_many_children
 end
 
 class ParanoidManyManyParentRight < ActiveRecord::Base
-  has_many :paranoid_many_many_children
+  acts_as_paranoid
+  belongs_to :paranoid_many_many_super_parent
+  has_many :paranoid_many_many_children, dependent: :destroy
   has_many :paranoid_many_many_parent_lefts, :through => :paranoid_many_many_children
 end
 
@@ -353,6 +373,9 @@ class ParanoidManyManyChild < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_many_many_parent_left
   belongs_to :paranoid_many_many_parent_right
+
+  validates_presence_of :paranoid_many_many_parent_left
+  validates_presence_of :paranoid_many_many_parent_right
 end
 
 class ParanoidWithScopedValidation < ActiveRecord::Base


### PR DESCRIPTION
A model would recover its dependents and then itself but that broke a lot of validations. If a dependent had a validation for the model to exist it would fail to be recovered. This patch proposes a more intelligent recovery, where models first recover models that they are dependent on, then they recover themselves, and then they recover their dependents. 
