### PR TITLE
Add code block formatting to Associations section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,6 +105,7 @@ Once you retrieve data using `with_deleted` scope you can check deletion status 
 ### Associations
 Associations are also supported. From the simplest behaviors you'd expect to more nifty things like the ones mentioned previously or the usage of the `:with_deleted` option with `belongs_to`
 
+```
 class ParanoiacParent < ActiveRecord::Base
 	has_many :children, :class_name => "ParanoiacChild"
 end
@@ -119,7 +120,8 @@ child = parent.children.create
 parent.destroy
 
 child.parent #=> nil
-child.parent_with_deleted #=> ParanoiacParent (it works!)
+child.parent_with_deleted #=> ParanoiacParent #it works!
+```
 
 ## Caveats
 


### PR DESCRIPTION
The formatting was missing from the Associations section of the ReadMe. This adds the formatting back to make it easier for other developers to read.